### PR TITLE
Lint cleanup: remove unused imports and f-string literals

### DIFF
--- a/scripts/council.py
+++ b/scripts/council.py
@@ -72,7 +72,6 @@ def collect_session_excerpts(forge_dir: Path, session_ids: list[str],
 
     excerpts = []
     in_target_session = False
-    current_session = ""
     line_count = 0
 
     with cache.open(encoding="utf-8") as f:
@@ -85,7 +84,6 @@ def collect_session_excerpts(forge_dir: Path, session_ids: list[str],
             if marker == "session_start":
                 sid = obj.get("session_short", "")[:8]
                 in_target_session = sid in session_ids
-                current_session = sid
                 if in_target_session:
                     excerpts.append(f"\n--- session {sid} ---")
                 continue
@@ -224,13 +222,13 @@ def frame_target(entry: dict, source_file: str, excerpts: str) -> str:
     
     body_parts = [
         f"# Target for council attack: {eid}",
-        f"",
-        f"## The crystallized entry",
-        f"",
+        "",
+        "## The crystallized entry",
+        "",
         f"**ID**: {eid}",
         f"**Source**: `{source_file}`",
         f"**Title**: {title}",
-        f"",
+        "",
     ]
     
     important_fields = [
@@ -253,7 +251,7 @@ def frame_target(entry: dict, source_file: str, excerpts: str) -> str:
         "",
         "## What's at stake",
         "",
-        f"This entry sits in the project's knowledge base. If it's wrong, downstream decisions inherit the error. If it gets copied into CLAUDE.md / AGENTS.md, the agent will operate on it as if true across all future sessions. The cost of being wrong is high.",
+        "This entry sits in the project's knowledge base. If it's wrong, downstream decisions inherit the error. If it gets copied into CLAUDE.md / AGENTS.md, the agent will operate on it as if true across all future sessions. The cost of being wrong is high.",
         "",
         "## Session excerpts that fed this entry",
         "",
@@ -463,8 +461,8 @@ def main():
 
     print(f"[insight-forge] Council prepared for {entry_id} at:", file=sys.stderr)
     print(f"  {out_dir}", file=sys.stderr)
-    print(f"[insight-forge] Next: agent should read README.md and orchestrate "
-          f"5 parallel sub-agents.", file=sys.stderr)
+    print("[insight-forge] Next: agent should read README.md and orchestrate "
+          "5 parallel sub-agents.", file=sys.stderr)
     print(str(out_dir))
 
 

--- a/scripts/extract_claude.py
+++ b/scripts/extract_claude.py
@@ -16,7 +16,6 @@ import argparse
 import json
 import os
 import sys
-import re
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Iterator, Optional
@@ -298,7 +297,7 @@ def main():
               file=sys.stderr)
         suggestions = fuzzy_suggest(args.project, claude_home)
         if suggestions:
-            print(f"[insight-forge] Did you mean one of:", file=sys.stderr)
+            print("[insight-forge] Did you mean one of:", file=sys.stderr)
             for s in suggestions:
                 print(f"  - {s}", file=sys.stderr)
         sys.exit(2)

--- a/scripts/pipeline.py
+++ b/scripts/pipeline.py
@@ -17,11 +17,10 @@ from __future__ import annotations
 
 import argparse
 import json
-import os
 import re
 import sys
 import unicodedata
-from dataclasses import dataclass, field, asdict
+from dataclasses import dataclass, field
 from datetime import datetime, timezone, timedelta
 from pathlib import Path
 from typing import Optional
@@ -142,7 +141,6 @@ def yaml_load_simple(text: str) -> dict:
     result = {}
     lines = text.split("\n")
     stack = [(0, result)]  # (indent, container)
-    current_list = None
 
     i = 0
     while i < len(lines):
@@ -699,7 +697,6 @@ class CrystallizationDecision:
 
 def detect_verbal_affirmation(observation: dict, candidates: list[CandidateEvent]) -> Optional[str]:
     """Look for first-person user affirmation within ~3 turns of the observation."""
-    obs_content = observation.get("content", "")
     obs_session = observation.get("session_id", "")[:8]
     obs_ts = observation.get("timestamp", "")
 
@@ -720,8 +717,8 @@ def detect_verbal_affirmation(observation: dict, candidates: list[CandidateEvent
 def detect_topic_abandonment(observation: dict, all_sessions: list[dict],
                               k: int = 5) -> bool:
     """Topic absent from last k sessions and no open_threads reference."""
-    obs_content = observation.get("content", "")
     obs_session = observation.get("session_id", "")[:8]
+    obs_content = observation.get("content", "")
 
     # Take noun-phrase keywords from observation
     keywords = [w.lower() for w in re.findall(r"\b[A-Za-z]{5,}\b", obs_content)][:5]

--- a/scripts/render_evidence.py
+++ b/scripts/render_evidence.py
@@ -57,11 +57,11 @@ def render_session(session_meta: dict, events: list[dict]) -> str:
     agent = session_meta.get("agent", "?")
     date = session_meta.get("mtime", "")[:10]
     size_kb = session_meta.get("size_kb", "?")
-    out.append(f'<div class="session">')
-    out.append(f'<div class="session-header">')
+    out.append('<div class="session">')
+    out.append('<div class="session-header">')
     out.append(f'  <strong>Session {escape(sid)}</strong> &nbsp;|&nbsp; ')
     out.append(f'agent: {escape(agent)} &nbsp;|&nbsp; date: {escape(date)} &nbsp;|&nbsp; size: {size_kb} KB &nbsp;|&nbsp; events: {len(events)}')
-    out.append(f'</div>')
+    out.append('</div>')
     last_date = ""
     for ev in events:
         ts = ev.get("timestamp", "")

--- a/scripts/run.py
+++ b/scripts/run.py
@@ -27,7 +27,6 @@ OPTIONS:
 from __future__ import annotations
 
 import argparse
-import json
 import os
 import subprocess
 import sys


### PR DESCRIPTION
Removes unused variables and imports (`current_session`, `current_list`, `os`, `re`, `json`, `asdict`), and replaces f-strings with no interpolation with plain strings across council.py, extract_claude.py, pipeline.py, render_evidence.py, run.py. No behavior change.