### PR TITLE
feat: user-facing output — quotes in proposals, friendly summary, actionable empty state

### DIFF
--- a/scripts/propose_claude_md.py
+++ b/scripts/propose_claude_md.py
@@ -18,6 +18,65 @@ import sys
 from datetime import datetime, timezone
 from pathlib import Path
 
+try:
+    import yaml as _yaml
+    _HAS_YAML = True
+except ImportError:
+    _HAS_YAML = False
+
+
+def _load_bundle(forge_dir: Path, entry_id: str) -> dict:
+    """Load the structured evidence bundle for an entry, or {} if missing."""
+    p = forge_dir / "evidence" / "bundles" / f"{entry_id}.yaml"
+    if not p.exists():
+        return {}
+    text = p.read_text(encoding="utf-8")
+    if _HAS_YAML:
+        try:
+            return _yaml.safe_load(text) or {}
+        except Exception:
+            return {}
+    # Fallback to the lite parser
+    try:
+        sys.path.insert(0, str(Path(__file__).resolve().parent))
+        from pipeline import yaml_load_simple  # noqa: E402
+        return yaml_load_simple(text) or {}
+    except Exception:
+        return {}
+
+
+def _format_quote(ev: dict) -> str:
+    """One-line markdown bullet describing an evidence event."""
+    quote = (ev.get("quote") or "").strip()
+    if len(quote) > 220:
+        quote = quote[:217] + "…"
+    quote = quote.replace("\n", " ")
+    ts = (ev.get("timestamp") or "")[:10]  # date only
+    role = ev.get("role") or ""
+    kind = ev.get("kind") or ""
+    label = {
+        "trigger": "*You said*" if role == "user" else "*Claude said*",
+        "verbal-affirmation": "*You confirmed*",
+        "empirical-resolution": "*Tool result*",
+        "topic-abandonment": "*Then untouched in subsequent sessions*",
+    }.get(kind, "*Evidence*")
+    when = f" ({ts})" if ts else ""
+    if kind == "topic-abandonment":
+        return f"  - {label}\n"
+    if not quote:
+        return f"  - {label}{when}\n"
+    return f"  - {label}{when}: \"{quote}\"\n"
+
+
+def _bundle_quotes(forge_dir: Path, entry_id: str) -> str:
+    """Render the trigger + closure quotes for an entry, ready to splice."""
+    bundle = _load_bundle(forge_dir, entry_id)
+    evidence = bundle.get("evidence") or []
+    if not evidence:
+        return ""
+    chunks = [_format_quote(ev) for ev in evidence]
+    return "".join(chunks)
+
 
 def parse_md_entries(text: str, prefix: str) -> list[dict]:
     """Parse entries of the form '## <prefix>NN: ...\\n- **Field**: value\\n...'"""
@@ -134,6 +193,7 @@ def build_proposal(forge_dir: Path, target: str, agent_name: str,
             counter = h.get("Counter-cases", "not_explored")
             sessions = h.get("Sessions", "[]")
             out.append(f"- **{h['id']}**: {rule}\n")
+            out.append(_bundle_quotes(forge_dir, h["id"]))
             if counter and counter != "not_explored":
                 out.append(f"  - *Caveat*: {counter}\n")
             out.append(f"  - *Sessions*: {sessions}\n\n")
@@ -146,6 +206,7 @@ def build_proposal(forge_dir: Path, target: str, agent_name: str,
             counter = c.get("Counter-evidence", "not_explored")
             sessions = c.get("Sessions", "[]")
             out.append(f"- **{c['id']}** *({status})*: {stmt}\n")
+            out.append(_bundle_quotes(forge_dir, c["id"]))
             if counter and counter != "not_explored":
                 out.append(f"  - *Counter-evidence*: {counter}\n")
             out.append(f"  - *Sessions*: {sessions}\n\n")
@@ -158,6 +219,7 @@ def build_proposal(forge_dir: Path, target: str, agent_name: str,
             could = d.get("Could have worked if", "")
             sessions = d.get("Sessions", "[]")
             out.append(f"- **{d['id']}**: avoid {avoid}\n")
+            out.append(_bundle_quotes(forge_dir, d["id"]))
             if lesson:
                 out.append(f"  - *Lesson*: {lesson}\n")
             if could and could != "not_explored":
@@ -229,8 +291,75 @@ def main():
     )
     out_path.parent.mkdir(parents=True, exist_ok=True)
     out_path.write_text(proposal, encoding="utf-8")
-    print(f"[insight-forge] Proposal written to {out_path}", file=sys.stderr)
+
+    # Friendly human-readable summary on stderr — what the user actually wants
+    # to see. The stdout contract (`out_path`) is preserved for run.py.
+    _print_summary(forge_dir, out_path, target, since)
     print(out_path)
+
+
+def _print_summary(forge_dir: Path, out_path: Path, target: str, since) -> None:
+    """Multi-line friendly digest of what was learned."""
+    logic = forge_dir / "logic"
+    h = parse_md_entries((logic / "heuristics.md").read_text(encoding="utf-8"), "H") \
+        if (logic / "heuristics.md").exists() else []
+    c = parse_md_entries((logic / "claims.md").read_text(encoding="utf-8"), "C") \
+        if (logic / "claims.md").exists() else []
+    d = parse_md_entries((logic / "dead_ends.md").read_text(encoding="utf-8"), "D") \
+        if (logic / "dead_ends.md").exists() else []
+
+    if since:
+        sidx = forge_dir / "trace" / "session_index.yaml"
+        h = filter_recent(h, since, sidx)
+        c = filter_recent(c, since, sidx)
+        d = filter_recent(d, since, sidx)
+
+    # Count staged observations not yet promoted (from staging YAML)
+    staged_pending = 0
+    obs_path = forge_dir / "staging" / "observations.yaml"
+    if obs_path.exists():
+        try:
+            text = obs_path.read_text(encoding="utf-8")
+            data = (_yaml.safe_load(text) if _HAS_YAML else None) or {}
+            staged_pending = sum(1 for o in (data.get("observations") or [])
+                                 if not o.get("promoted") and not o.get("stale"))
+        except Exception:
+            pass
+
+    target_label = target if target != "BOTH" else "CLAUDE.md & AGENTS.md"
+
+    sys.stderr.write("\n")
+    sys.stderr.write(f"  Insight Forge — proposal for {target_label}\n")
+    sys.stderr.write("  " + "─" * 56 + "\n")
+    if not (h or c or d):
+        sys.stderr.write("  Nothing new crystallized yet — the pipeline saw your\n")
+        sys.stderr.write("  sessions but no observation has hit a closure signal.\n")
+        sys.stderr.write("  Use the project a bit more, then re-run.\n")
+    else:
+        if h:
+            sys.stderr.write(f"  ✓ {len(h)} project rule{'s' if len(h) != 1 else ''} ready\n")
+            for entry in h[:3]:
+                rule = entry.get("Rule", entry.get("title", ""))[:80]
+                sys.stderr.write(f"      • {rule}\n")
+            if len(h) > 3:
+                sys.stderr.write(f"      … and {len(h) - 3} more\n")
+        if d:
+            sys.stderr.write(f"  ✗ {len(d)} dead end{'s' if len(d) != 1 else ''} to avoid\n")
+            for entry in d[:2]:
+                avoid = entry.get("Avoid signal", entry.get("title", ""))[:80]
+                sys.stderr.write(f"      • {avoid}\n")
+            if len(d) > 2:
+                sys.stderr.write(f"      … and {len(d) - 2} more\n")
+        if c:
+            sys.stderr.write(f"  ? {len(c)} claim{'s' if len(c) != 1 else ''} (project facts)\n")
+
+    if staged_pending:
+        sys.stderr.write(f"  · {staged_pending} observation{'s' if staged_pending != 1 else ''} "
+                         f"still in staging (need more sessions)\n")
+
+    sys.stderr.write("\n")
+    sys.stderr.write(f"  Full proposal — open or paste from:\n")
+    sys.stderr.write(f"    {out_path}\n\n")
 
 
 if __name__ == "__main__":

--- a/scripts/run.py
+++ b/scripts/run.py
@@ -70,6 +70,24 @@ def detect_agents(claude_home: Path, codex_home: Path) -> list[str]:
     return found
 
 
+def _print_no_sessions_help(claude_home: Path, codex_home: Path) -> None:
+    """Print actionable empty-state guidance instead of a bare error."""
+    sys.stderr.write("\n")
+    sys.stderr.write("  Insight Forge couldn't find any AI coding sessions on this machine.\n\n")
+    sys.stderr.write("  insight-forge analyzes the JSONL transcripts your AI assistant writes\n")
+    sys.stderr.write("  while you work. It looks in two places:\n\n")
+    sys.stderr.write(f"    Claude Code: {claude_home}/projects/\n")
+    sys.stderr.write(f"    Codex CLI:   {codex_home}/sessions/\n\n")
+    sys.stderr.write("  Neither directory exists yet on this machine.\n\n")
+    sys.stderr.write("  What to do next:\n")
+    sys.stderr.write("    1. Use Claude Code or Codex CLI for a few minutes in any project.\n")
+    sys.stderr.write("       Sessions are saved automatically as you go.\n")
+    sys.stderr.write("    2. Re-run insight-forge from inside that project's directory.\n\n")
+    sys.stderr.write("  Already used your AI here but still seeing this? Try:\n")
+    sys.stderr.write("    python3 scripts/run.py --fuzzy-cwd\n\n")
+    sys.stderr.write("  (matches sessions whose recorded cwd is a parent or child of yours.)\n\n")
+
+
 def extract(agent: str, project: str, since: str | None,
             out: Path, args: argparse.Namespace) -> bool:
     """Call the right extractor. Returns True if it produced output."""
@@ -154,8 +172,7 @@ def main():
     if args.agent == "auto":
         agents = detect_agents(claude_home, codex_home)
         if not agents:
-            print("[insight-forge] No Claude Code or Codex sessions found on this machine.",
-                  file=sys.stderr)
+            _print_no_sessions_help(claude_home, codex_home)
             sys.exit(1)
     else:
         agents = [args.agent]
@@ -185,8 +202,16 @@ def main():
             extracted_parts.append(out)
 
     if not extracted_parts:
-        print("[insight-forge] No new sessions to process since last run. Nothing to do.",
-              file=sys.stderr)
+        sys.stderr.write("\n")
+        if since:
+            sys.stderr.write(f"  No new sessions since {since[:10]}.\n")
+            sys.stderr.write(f"  insight-forge stays incremental — nothing to do until you\n")
+            sys.stderr.write(f"  use your AI assistant again in this project.\n\n")
+        else:
+            sys.stderr.write(f"  No sessions found for this project's directory.\n")
+            sys.stderr.write(f"    Project: {project}\n\n")
+            sys.stderr.write(f"  If you have used your AI from a parent or sibling directory,\n")
+            sys.stderr.write(f"  try:  python3 scripts/run.py --fuzzy-cwd\n\n")
         # Still update .last_run so the cursor advances
         last_run_file = forge_dir / ".last_run"
         now = datetime.now(timezone.utc).isoformat(timespec="seconds")
@@ -214,35 +239,17 @@ def main():
     _run(pipeline_cmd, "Running pipeline (Harvester → Router → Maturity Tracker)…")
 
     # ── Generate proposal ─────────────────────────────────────
+    # Capture stdout (the path) but let stderr flow through so the user
+    # sees the friendly summary printed by propose_claude_md.py.
     proposal_cmd = [sys.executable, str(SCRIPTS / "propose_claude_md.py"),
                     "--forge-dir", str(forge_dir)]
     if since:
         # Pass date-only portion so proposal filters to new knowledge
         proposal_cmd += ["--since", since[:10]]
-    result = subprocess.run(proposal_cmd, capture_output=True, text=True)
-    proposal_path = result.stdout.strip()
-    if result.returncode == 0 and proposal_path:
-        print(f"[insight-forge] Proposal ready: {proposal_path}", file=sys.stderr)
-    else:
+    result = subprocess.run(proposal_cmd, stdout=subprocess.PIPE, text=True)
+    proposal_path = (result.stdout or "").strip()
+    if result.returncode != 0:
         print("[insight-forge] Warning: proposal generation failed", file=sys.stderr)
-        if result.stderr:
-            print(result.stderr, file=sys.stderr)
-
-    # ── Print summary ─────────────────────────────────────────
-    summary_path = forge_dir / "trace" / "pipeline_log.yaml"
-    summary_line = ""
-    if summary_path.exists():
-        lines = summary_path.read_text(encoding="utf-8").splitlines()
-        # Last run entry is at the bottom — grab the key counts
-        for line in reversed(lines):
-            if "candidates:" in line or "crystallized:" in line:
-                summary_line = line.strip()
-                break
-
-    agents_str = " + ".join(agents)
-    print(f"\n[insight-forge] Done ({agents_str}) — {summary_line}", file=sys.stderr)
-    if proposal_path:
-        print(f"[insight-forge] → Review: {proposal_path}", file=sys.stderr)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Why

PRs #16/#17/#18 shipped solid engineering — eval harness, evidence bundles, portable rule spec, eval-graded proposer — but **none of it surfaces to a casual user**. Someone who installs the skill and types `/insight-forge` for the first time sees:

1. Stage logs in stderr ("Stage 1 — Harvested 47 candidates from 12 sessions")
2. A path to a proposal file
3. They have to open the file in their editor to see anything

And when they do open it, they see `H01: Always use pnpm` with `Sessions: [aaaa1111]` — no quote, no date, no explanation. They think "why is this rule here?" and bounce.

This PR doesn't add features. It surfaces what the pipeline already learned in a form a human can read in 30 seconds.

## Three changes

### 1. Splice quotes from evidence bundles into proposals

The bundles introduced in PR #16 already store trigger and closure quotes verbatim. `propose_claude_md.py` now reads them and renders them inline:

```markdown
### Heuristics (project rules)

- **H01**: Always use pnpm for this repo, never npm.
  - *You said* (2026-05-01): "Always use pnpm for this repo, never npm."
  - *You confirmed* (2026-05-01): "yes parfait, on part sur pnpm"
  - *Caveat*: Doesn't apply when the underlying assumptions break down.
  - *Sessions*: [aaaa1111]
```

Now every suggestion is self-explanatory. The user sees their own words, dated.

### 2. Friendly summary on stderr after every run

```
  Insight Forge — proposal for CLAUDE.md
  ────────────────────────────────────────────────────────
  ✓ 3 project rules ready
      • Use pnpm not npm
      • Always run lint:fix before committing
      • Tests live in tests/, not __tests__/
  ✗ 1 dead end to avoid
      • Don't use the npm run validate script
  · 5 observations still in staging (need more sessions)

  Full proposal — open or paste from:
    .insight-forge/proposals/2026-05-05T12-28-15Z.md
```

The summary is computed inside `propose_claude_md.py` so it stays consistent with the proposal markdown. `run.py` stops capturing the proposal subprocess's stderr — it just flows through to the user's terminal. The stdout contract (the proposal path) is preserved so existing automation isn't broken.

### 3. Actionable empty state

Two paths get the same treatment:

**No sessions on this machine** — used to be `exit 1` with a one-liner. Now:
```
  Insight Forge couldn't find any AI coding sessions on this machine.

  insight-forge analyzes the JSONL transcripts your AI assistant writes
  while you work. It looks in two places:

    Claude Code: /Users/loic/.claude/projects/
    Codex CLI:   /Users/loic/.codex/sessions/

  Neither directory exists yet on this machine.

  What to do next:
    1. Use Claude Code or Codex CLI for a few minutes in any project.
       Sessions are saved automatically as you go.
    2. Re-run insight-forge from inside that project's directory.

  Already used your AI here but still seeing this? Try:
    python3 scripts/run.py --fuzzy-cwd
```

**No new sessions since last run** — used to be a flat "Nothing to do." Now explains incremental design and suggests `--fuzzy-cwd` if the user expected new data.

## What stays unchanged

- The harness/rules/bundles internals are still invisible to users. They're contributor-facing, and that's correct.
- The stdout contract of `propose_claude_md.py` (proposal path on stdout) — automation keeps working.
- All eval contracts: 5/5 fixtures pass, false_promotion_rate=0%, all rule contracts hold.
- Conservative-by-default: still no auto-edit of CLAUDE.md / AGENTS.md.

## Test plan

- [x] `python3 scripts/pipeline.py --input evals/fixtures/simple_success.jsonl --forge-dir /tmp/x && python3 scripts/propose_claude_md.py --forge-dir /tmp/x` — produces friendly summary + spliced quotes
- [x] `python3 scripts/run.py --claude-home /tmp/none --codex-home /tmp/none` — shows the no-sessions help screen, exits 1
- [x] `python3 scripts/run_evals.py` — 5/5 pass, no regressions
- [x] `python3 scripts/run_evals.py --verify-contracts` — all rule contracts hold

🤖 Generated with [Claude Code](https://claude.com/claude-code)