### PR TITLE
docs: rewrite README for the casual reader

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ And most of it is gone.
 
 Buried in JSONL files. Scattered across transcripts. Half-remembered in a `CLAUDE.md` that's grown into a graveyard of overconfident rules nobody dares touch.
 
-**insight-forge reads every session you've ever had and crystallizes what actually matters.**
+**insight-forge reads every session you've ever had and tells you what you actually learned.**
 
-Not summaries. Not guesses. Typed knowledge — with evidence, with counter-arguments, promoted only when earned.
+Not summaries. Not guesses. Project rules and dead ends — quoted from your own words, dated, with the moment you confirmed each one.
 
 ---
 
@@ -32,34 +32,43 @@ That's it. Your agent handles the rest.
 
 ---
 
-## The problem with AI memory
+## What you'll see
 
-Every session ends, and the learning stays locked in the transcript.
+Run it once. You'll get a friendly summary in your terminal:
 
-Over time, your `CLAUDE.md` accumulates contradictions. Rules that worked once, rules that no longer apply, rules that contradict each other. You don't know what to trust.
+```
+  Insight Forge — proposal for CLAUDE.md
+  ────────────────────────────────────────────────────────
+  ✓ 3 project rules ready
+      • Use pnpm not npm
+      • Always run lint:fix before committing
+      • Tests live in tests/, not __tests__/
+  ✗ 1 dead end to avoid
+      • Don't use the npm run validate script
+  · 5 observations still in staging (need more sessions)
 
-The AI that's helping you build things has no idea what the AI from last month already learned.
+  Full proposal — open or paste from:
+    .insight-forge/proposals/2026-05-05T12-28-15Z.md
+```
+
+Open the proposal and every suggestion shows you why it's there:
+
+```markdown
+### Heuristics (project rules)
+
+- **H01**: Use pnpm not npm
+  - *You said* (May 1): "Always use pnpm for this repo, never npm."
+  - *You confirmed* (May 1): "yes parfait, on part sur pnpm"
+  - *Sessions*: [aaaa1111]
+```
+
+Nothing is invented. Every line cites the moment in your transcripts where you actually earned it.
 
 ---
 
-## One command. Every session. What you actually learned.
+## How it decides what to keep
 
-```
-/insight-forge
-```
-
-Scans your Claude Code or Codex CLI sessions since the last run.  
-Extracts research-significant events.  
-Promotes only what has earned promotion.  
-Proposes a diff for your `CLAUDE.md` — and never touches it directly.
-
-The decision is always yours.
-
----
-
-## How it knows what to trust
-
-Four signals — and four signals only — trigger crystallization:
+Four signals — and four signals only — earn a place in your proposal:
 
 | Signal | What it means |
 |---|---|
@@ -68,10 +77,10 @@ Four signals — and four signals only — trigger crystallization:
 | **Empirical resolution** | A tool execution confirmed or refuted the hypothesis. |
 | **Artifact commitment** | Code or config now depends on it. It shipped. |
 
-Everything else stays in staging.  
+Everything else stays in staging.
 No scoring. No LLM-judged maturity. No guessing.
 
-**Default: do not promote.**  
+**Default: do not promote.**
 The failure mode this tool prevents is not missing insights — it's overconfident promotions that quietly corrupt your configuration.
 
 ---
@@ -80,7 +89,7 @@ The failure mode this tool prevents is not missing insights — it's overconfide
 
 Before anything reaches your `CLAUDE.md`, insight-forge must articulate what would disprove it.
 
-Vague counters are rejected by a hedging lint. Phrases that stay true regardless of project — gone. If no concrete counter can be found, the entry is flagged, not promoted.
+Vague counters are rejected. Phrases that stay true regardless of project — gone. If no concrete counter can be found, the entry is flagged, not promoted.
 
 For your most load-bearing beliefs: `--council` mode sends five structurally incompatible critics at a single claim — simultaneously — then synthesizes a verdict.
 
@@ -88,16 +97,15 @@ It's expensive. It's the point.
 
 ---
 
-## What you get after every run
+## What lands on disk after each run
 
 ```
 .insight-forge/
 ├── proposals/2026-05-03T14-22-05Z.md   ← what to add to your CLAUDE.md
-├── logic/claims.md                      ← falsifiable assertions + counter-evidence
 ├── logic/heuristics.md                  ← rules that actually held up
+├── logic/claims.md                      ← falsifiable assertions
 ├── logic/dead_ends.md                   ← failures, and what could have rescued them
-├── evidence/bundles/H01.yaml            ← machine-readable provenance per entry
-└── evidence/sessions.html               ← forensic iMessage-style session viewer
+└── evidence/                            ← which words earned each promotion
 ```
 
 Proposals are organized by epistemic confidence:
@@ -108,151 +116,15 @@ Proposals are organized by epistemic confidence:
 
 ---
 
-## Every claim is auditable
+## Why you can trust it
 
-Markdown is for humans. Evidence bundles are for machines.
+- **Every suggestion cites your transcripts.** Each rule shows the exact phrase you used and the moment you confirmed it. If a claim is ever challenged, the receipts are right there.
+- **Conservative by default.** No promotion without one of the four signals above. When in doubt, the answer is *stay in staging*.
+- **Regression-tested.** A suite of synthetic transcripts asserts what should and shouldn't crystallize. Pipeline changes that would let an over-confident rule slip through fail the build.
+- **Never auto-edits anything.** insight-forge writes to `.insight-forge/proposals/`. Your `CLAUDE.md` only changes when you decide to copy something into it.
 
-Every crystallized entry gets a YAML file at `evidence/bundles/<entry_id>.yaml`
-that names exactly which user phrase, which tool result, or which abandoned topic
-earned its promotion:
-
-```yaml
-entry_id: H01
-target_layer: heuristic
-crystallized_via: verbal-affirmation
-sessions: [aaaa1111]
-evidence:
-  - kind: trigger
-    role: user
-    quote: "Always use pnpm for this repo, never npm."
-  - kind: verbal-affirmation
-    role: user
-    quote: "yes parfait, on part sur pnpm"
-counter_evidence:
-  text: "Doesn't apply when the underlying assumptions break down."
-  source: deterministic-template
-promotion_gate:
-  passed: true
-  reason: "User affirmation phrase: 'yes'"
-```
-
-If a claim ever needs to be challenged, contradicted, or upgraded — the bundle is
-the source of truth. Markdown can't lie when YAML is watching.
-
----
-
-## The harness is data, not code
-
-The classifier rules — *what counts as a heuristic, what counts as a
-constraint, what counts as a falsifiable claim* — used to live as Python
-regex inside the pipeline. Now they live in [`harness/rules.yaml`](harness/rules.yaml):
-
-```yaml
-- id: R-CONSTRAINT-MUST-REQUIRES
-  when:
-    role: user
-    content_matches_regex: "\\b(must|requires|doit|nécessite)\\s+\\S+"
-  unless:
-    any:
-      - content_length_gt: 400
-      - content_starts_with_imperative: true
-  emit:
-    route: staged
-    type: constraint
-    confidence: medium
-  contract:
-    must_not_fire_on:
-      - false_positive_instruction
-```
-
-Three things this gives you:
-
-1. **You can edit the rules without touching code.** Change a regex, add a
-   phrase, tighten a length threshold — `rules.yaml` is the spec.
-2. **Every rule is contracted to evals.** `must_fire_on` / `must_not_fire_on`
-   name the fixtures the rule is responsible for. `python3 scripts/run_evals.py
-   --verify-contracts` enforces them. A rule whose contract fails is a rule
-   that can't ship.
-3. **It builds the substrate for measured improvement** — see below.
-
-Full spec: [`harness/README.md`](harness/README.md).
-
----
-
-## The proposer closes the loop
-
-Once the harness is data with measurable contracts, you can have a script
-edit it for you and grade itself by the metric you actually care about.
-
-```bash
-python3 scripts/propose_rules.py
-```
-
-```
-[propose] gap fixture: french_heuristic (target: R-HEURISTIC-ALWAYS-NEVER)
-[propose] evaluating 9 candidate phrase(s)...
-  ✓ 'il' → score=1 (ok)
-  ✓ 'il faut' → score=1 (ok)
-  ✓ 'il faut toujours' → score=1 (ok)
-  · 'compris' → score=0 (ok)
-  ...
-[propose] Proposal written: harness/proposals/2026-05-05T12-15-50Z-R-HEURISTIC-ALWAYS-NEVER.yaml
-```
-
-Mark a fixture as a known gap (`known_gap: true` + `target_rule: R-...` in
-its `expected.yaml`) and the proposer will:
-
-1. Generate candidate mutations on the target rule (currently: extending
-   regex alternations with leading 1-3 token phrases extracted from the
-   fixture).
-2. Sandbox each candidate — write a temp `rules.yaml`, run the **full**
-   eval suite + contract verifier against it.
-3. Score `+1` per gap fixture closed, `-∞` for any regression on a passing
-   fixture or any contract violation.
-4. Write the highest-scoring candidate to `harness/proposals/<ts>.yaml` —
-   with the `before`/`after` diff, the metric delta, and apply
-   instructions. **Never** edits `rules.yaml` directly. You review and
-   apply by hand, exactly like the `CLAUDE.md` proposal flow.
-
-This is the Stanford *Meta-Harness* loop — proposer, sandbox, eval,
-contract — done with a deterministic baseline. The mutation generator is
-the single swappable seam: an LLM-based generator drops in without
-changing the sandboxing or scoring code.
-
----
-
-## Measured, not just felt
-
-insight-forge ships with a regression harness — `evals/` — that runs synthetic
-transcripts through the full pipeline and asserts what *should* and *should not*
-crystallize.
-
-```bash
-python3 scripts/run_evals.py
-```
-
-```
-  [PASS] abandoned_topic            signals=['topic-abandonment']
-  [PASS] empirical_resolution       signals=['empirical-resolution']
-  [PASS] false_positive_instruction signals=[]
-  [PASS] no_signal                  signals=[]
-  [PASS] simple_success             signals=['verbal-affirmation']
-
-  fixtures: 5/5 passed
-  false_promotion_rate:  0.00%
-  missed_promotion_rate: 0.00%
-  provenance_coverage:   100.00%
-```
-
-The load-bearing metric is **`false_promotion_rate`** — anything above 0 % means
-the pipeline crystallized something that shouldn't have. The whole tool exists to
-keep that number at zero.
-
-Add a fixture, write its expected outcome, run the harness. Pipeline changes
-that regress any of the five reference cases fail the build.
-
-See [`evals/README.md`](evals/README.md) for the fixture format and how to add
-your own.
+How it's built — pipeline, classifier rules, eval harness, contributor guide:
+[`TECHNICAL.md`](TECHNICAL.md), [`harness/README.md`](harness/README.md), [`evals/README.md`](evals/README.md).
 
 ---
 
@@ -260,16 +132,18 @@ your own.
 
 insight-forge never re-reads sessions it has already processed.
 
-After each run, it writes a `.last_run` timestamp to `.insight-forge/`. The next run passes that timestamp as `--since` to the extractor — only sessions modified after that date are read. A month later, only the past month's sessions are extracted. Previously processed JSONL files are never touched again.
+After each run, it writes a `.last_run` timestamp to `.insight-forge/`. The next run passes that timestamp to the extractor — only sessions modified after that date are read. A month later, only the past month's sessions are extracted. Previously processed JSONL files are never touched again.
+
+---
 
 ## Every mode
 
 ```bash
-/insight-forge                      # Default: scan new sessions only, crystallize, propose
+/insight-forge                      # Default: scan new sessions, propose
 /insight-forge --challenge          # 6-axis stress-test of crystallized claims
 /insight-forge --council C03        # 5-attacker verdict on a single entry
 /insight-forge --evidence C03       # Show which sessions fed this claim
-/insight-forge --since 2026-04-01   # Override cursor: process from a specific date
+/insight-forge --since 2026-04-01   # Process from a specific date
 /insight-forge --rebuild            # Wipe .insight-forge and reprocess everything
 ```
 
@@ -301,12 +175,6 @@ insight-forge is not a new idea — it's a disciplined combination of existing w
 What insight-forge adds: cross-session post-hoc processing, agent-agnostic normalization, and Devil's Advocate wired into the crystallization gate — not bolted on after.
 
 Full attribution in [TECHNICAL.md](TECHNICAL.md).
-
----
-
-## Technical reference
-
-Schemas, pipeline internals, script usage, failure modes, and full architecture documentation: **[TECHNICAL.md](TECHNICAL.md)**
 
 ---
 


### PR DESCRIPTION
## Why

PRs #16/#17/#18 added serious infrastructure — eval harness, evidence bundles, portable rule spec, eval-graded proposer — and the README grew four heavy sections to advertise it. A casual reader landing on the GitHub repo now hits *\"Tsinghua NLAH\"* and *\"false_promotion_rate\"* before they understand what the tool actually does. They bounce.

The infrastructure is good. It's just **contributor-facing** — and contributor docs already exist (`harness/README.md`, `evals/README.md`, `harness/proposals/README.md`). The marketing README doesn't need to recap them.

## What changes

### Removed from the README (still alive in their proper docs)
- ❌ *\"Every claim is auditable\"* with the bundle YAML schema → kept in `harness/README.md`-adjacent docs
- ❌ *\"The harness is data, not code\"* with `rules.yaml` schema → full spec in `harness/README.md`
- ❌ *\"The proposer closes the loop\"* with Stanford Meta-Harness reference → in `harness/README.md` + `harness/proposals/README.md`
- ❌ *\"Measured, not just felt\"* with eval output and `false_promotion_rate` → in `evals/README.md`

### Added
- ✅ **\"What you'll see\"** section near the top — shows the friendly stderr summary (PR #19) and a spliced-quote example from the proposal markdown. This is the wow moment that was missing.
- ✅ **\"Why you can trust it\"** — single tight block, 4 bullets, no jargon, no YAML, no academic citations. Each bullet links to the depth.

### Net effect
- **316 lines → 183 lines** (≈ 40% shorter)
- Zero academic citations in the marketing README (Tsinghua / Stanford / Meta-Harness / NLAH all gone)
- Every cut piece is one click away for the reader who wants depth

## Test plan

- [x] Read top-to-bottom from the perspective of someone who's never seen this repo. Question to ask: *\"Do I want to install this in 30 seconds?\"* — answer is yes, without needing to understand any internal vocabulary.
- [x] Every internal link still resolves (`TECHNICAL.md`, `harness/README.md`, `evals/README.md`).
- [x] Marketing voice (Apple-ish, declarative, short sentences) preserved throughout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)