### PR TITLE
docs: explain the harness techniques actually used + add references

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,32 @@ One installation. Both agents. No configuration.
 
 ---
 
+## The research it draws on
+
+Two recent academic papers shaped how the project stays trustworthy as it grows. The implementations aren't decorative — they ship in the codebase today.
+
+### The classifier rules live as data, not code
+
+> *Pan et al., **Natural-Language Agent Harnesses**, Tsinghua University, 2026.*
+> arXiv: [2603.25723](https://arxiv.org/abs/2603.25723)
+
+The paper argues that an agent's control logic should live as a portable, editable artifact — not buried in Python regex inside a controller script.
+
+**What this means in insight-forge.** The classifier rules — *what counts as a heuristic, what counts as a constraint, what counts as a falsifiable claim* — live in [`harness/rules.yaml`](harness/rules.yaml). You can edit a regex, add a phrase, tighten a length threshold, all without touching code. Each rule names which test fixtures it must (or must not) fire on, so a careless edit fails immediately with a contract violation. And every promotion writes a `evidence/bundles/<id>.yaml` file naming the exact transcript moment that earned it — readable by humans, queryable by tools.
+
+### A safe loop that improves the rules over time
+
+> *Lee et al., **Meta-Harness: End-to-End Optimization of Model Harnesses**, Stanford University, 2026.*
+> arXiv: [2603.28052](https://arxiv.org/abs/2603.28052)
+
+The paper shows that once a harness is data with measurable contracts, an automated proposer can edit it and grade itself by how the eval metrics move.
+
+**What this means in insight-forge.** When you find a real session where a rule should have fired but didn't, you mark the case as a *known gap* in the test fixtures. Then run [`scripts/propose_rules.py`](scripts/propose_rules.py) — it generates candidate edits, sandboxes each in a temporary copy of `rules.yaml`, runs the full test suite against it, and only surfaces edits that close the gap **without breaking any existing case**. The result lands in `harness/proposals/` for you to review. The proposer never edits `rules.yaml` directly — same conservative contract as the `CLAUDE.md` proposal flow.
+
+The current proposer is deterministic (no LLM cost, fully reproducible). The mutation generator is the single swappable seam — an LLM-based generator drops in without touching the sandboxing or scoring code.
+
+---
+
 ## Built on proven methodology
 
 insight-forge is not a new idea — it's a disciplined combination of existing work:
@@ -175,6 +201,21 @@ insight-forge is not a new idea — it's a disciplined combination of existing w
 What insight-forge adds: cross-session post-hoc processing, agent-agnostic normalization, and Devil's Advocate wired into the crystallization gate — not bolted on after.
 
 Full attribution in [TECHNICAL.md](TECHNICAL.md).
+
+---
+
+## References
+
+Academic papers that directly shape the implementation:
+
+- Pan, L., Zou, L., Guo, S., Ni, J., Zheng, H.-T. (2026). *Natural-Language Agent Harnesses*. Tsinghua University. [arXiv:2603.25723](https://arxiv.org/abs/2603.25723)
+- Lee, Y., Nair, R., Zhang, Q., Lee, K., Khattab, O., Finn, C. (2026). *Meta-Harness: End-to-End Optimization of Model Harnesses*. Stanford University. [arXiv:2603.28052](https://arxiv.org/abs/2603.28052)
+
+Methodology and source projects (full attribution in [TECHNICAL.md](TECHNICAL.md)):
+
+- ARA — [Orchestra-Research/Agent-Native-Research-Artifact](https://github.com/Orchestra-Research/Agent-Native-Research-Artifact)
+- creation-autopsy — [Sandjab/skills-that-kill](https://github.com/Sandjab/skills-that-kill)
+- codex-history-list — [shinshin86/codex-history-list](https://github.com/shinshin86/codex-history-list)
 
 ---
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -324,13 +324,26 @@ Override `.last_run` and process from a specific date. Useful for backfill.
 
 ## Scripts
 
+**User-facing entry point** — what the skill invokes when triggered:
+
+- `scripts/run.py` — single-command orchestrator. Reads `.last_run`, calls the right extractor(s) with `--since`, runs the pipeline, generates the proposal, prints the friendly summary, updates the cursor. **This is what the skill calls.** Everything else below is invoked transitively by it.
+
+**Pipeline internals** (called by `run.py`):
+
 - `scripts/extract_claude.py` — locate `~/.claude/projects/<encoded-cwd>/*.jsonl`, output filtered events
 - `scripts/extract_codex.py` — locate `~/.codex/sessions/YYYY/MM/DD/rollout-*.jsonl`, filter by `<environment_context>` cwd
-- `scripts/normalize.py` — convert either format to a common pivot schema
-- `scripts/pipeline.py` — Harvester → Router → Maturity, the ARA core
+- `scripts/pipeline.py` — Harvester → Router → Maturity, the ARA core. Lazy-loads classifier rules from `harness/rules.yaml`. Writes evidence bundles to `.insight-forge/evidence/bundles/`.
 - `scripts/render_evidence.py` — iMessage-style HTML annex (adapted from creation-autopsy)
-- `scripts/propose_claude_md.py` — generate the diff proposal
+- `scripts/propose_claude_md.py` — generate the diff proposal. Splices quotes from evidence bundles into the markdown; prints the friendly summary on stderr.
+
+**On-demand modes** (user-invocable through `run.py` flags):
+
 - `scripts/council.py` — prepare a 5-attacker council session for a single entry (no LLM calls itself; agent orchestrates)
+
+**Contributor tooling** (not invoked by the skill — for maintaining the project itself):
+
+- `scripts/run_evals.py` — regression eval harness. Runs synthetic transcripts under `evals/fixtures/` through the pipeline and asserts behavior. `--verify-contracts` validates each rule against its `must_fire_on` / `must_not_fire_on` fixtures.
+- `scripts/propose_rules.py` — eval-graded mutation search over `harness/rules.yaml`. Generates candidate edits to classifier rules; writes proposals to `harness/proposals/`. Never auto-applies.
 
 ## Compatibility
 


### PR DESCRIPTION
## Why

PR #20 rewrote the README for accessibility and (correctly) cut every Tsinghua / Stanford / *NLAH* / *Meta-Harness* reference from the marketing body. But that left a gap: a reader who *does* care about whether the trust claims are grounded — *\"is this actually built on something, or are you just claiming it?\"* — couldn't tell.

The two papers aren't decorative. They directly shape the implementation:

| Paper | Lives in |
|---|---|
| Tsinghua *NLAH* (Pan et al., 2026) | `harness/rules.yaml` + per-rule `contract` block + `evidence/bundles/*.yaml` |
| Stanford *Meta-Harness* (Lee et al., 2026) | `scripts/propose_rules.py` + the sandbox-and-score loop |

This PR adds a single section explaining each in plain language, with a formal references block at the very end.

## What lands

### \"Research it draws on\" section (before \"Built on proven methodology\")

Two short blocks, one per paper. Each block:
- One-line citation with arXiv link
- One paragraph: *what the paper says*
- One paragraph: *what that means in this codebase*, with file paths linked

No formulas, no acronyms, no jargon. The phrasing assumes the reader has never seen the paper.

### \"References\" section at the bottom

```markdown
- Pan, L., Zou, L., Guo, S., Ni, J., Zheng, H.-T. (2026). *Natural-Language
  Agent Harnesses*. Tsinghua University. arXiv:2603.25723
- Lee, Y., Nair, R., Zhang, Q., Lee, K., Khattab, O., Finn, C. (2026).
  *Meta-Harness: End-to-End Optimization of Model Harnesses*. Stanford
  University. arXiv:2603.28052
```

Plus a compact methodology credits list pointing at TECHNICAL.md for full attribution.

## Net effect

- README: 183 → 224 lines (+41)
- Casual reader still gets the marketing flow without academic friction
- Curious reader sees, in plain language, that the techniques are *built in*, not name-dropped
- Researcher / contributor sees the formal citations they expect, with arXiv links to follow

🤖 Generated with [Claude Code](https://claude.com/claude-code)