### PR TITLE
feat: minimal insight-forge CLI + CONTRIBUTING.md

### DIFF
--- a/.github/workflows/evals.yml
+++ b/.github/workflows/evals.yml
@@ -25,22 +25,29 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Install runtime + dev deps
+      - name: Install package + dev deps
         run: |
           python -m pip install --upgrade pip
-          pip install pyyaml pytest jsonschema
+          pip install -e ".[dev]"
+
+      # Sanity: the CLI must boot. Catches packaging mistakes (missing
+      # __init__.py, broken entry point) before downstream gates run.
+      - name: CLI smoke test
+        run: |
+          insight-forge --version
+          insight-forge --help
 
       - name: Regression evals
-        run: python3 scripts/run_evals.py
+        run: insight-forge eval
 
       - name: Verify harness contracts
-        run: python3 scripts/run_evals.py --verify-contracts
+        run: insight-forge eval --verify-contracts
 
       - name: Proposer dry-run
-        run: python3 scripts/propose_rules.py --dry-run
+        run: insight-forge propose --dry-run
 
       - name: Unit tests
-        run: python3 -m pytest tests/ -v
+        run: pytest
 
-      - name: Validate evidence bundle schema
-        run: python3 scripts/validate_evidence.py --evals
+      - name: Validate evidence bundle schema + traceability
+        run: insight-forge validate-evidence --evals

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,129 @@
+# Contributing
+
+Thanks for considering a contribution. The project's design — *conservative
+by default, every promotion verifiable, no auto-edits* — sets a clear bar
+for what changes can ship.
+
+## Setup
+
+```bash
+git clone https://github.com/bacoco/insight-forge
+cd insight-forge
+
+python -m venv .venv
+source .venv/bin/activate    # Windows: .venv\Scripts\activate
+
+pip install -e ".[dev]"
+```
+
+Requires Python ≥ 3.10. `pyyaml`, `pytest`, and `jsonschema` come as part
+of the `[dev]` extras.
+
+## The four quality gates
+
+Every change must pass these four gates (CI enforces all of them on every PR):
+
+```bash
+# 1. Regression evals — fixtures + signal counts + provenance
+insight-forge eval
+
+# 2. Harness contracts — every rule's must_fire_on / must_not_fire_on holds
+insight-forge eval --verify-contracts
+
+# 3. Unit tests — YAML fallback, predicates, schema, contracts, CLI
+pytest
+
+# 4. Evidence traceability — every quote is a substring of its source
+insight-forge validate-evidence --evals
+```
+
+If you can't get all four green locally, you can still open a PR — CI will
+tell you exactly which gate fails on the matrix (Python 3.10 / 3.11 / 3.12).
+
+## Common contribution patterns
+
+### Adding an eval fixture
+
+Most behavior contracts live as pairs under `evals/`:
+
+1. Create `evals/fixtures/<name>.jsonl` — synthetic normalized JSONL
+   (one event per line, bracketed by `_marker: session_start` / `session_end`).
+   See `evals/README.md` for the format.
+
+2. Create `evals/expected/<name>.expected.yaml` — what should and shouldn't
+   crystallize. Optional fields:
+   - `known_gap: true` — a fixture the proposer should target. Skipped from
+     regression but visible in output.
+   - `target_rule: R-...` — the rule the proposer should mutate.
+
+3. Run `insight-forge eval --fixture <name>`. Fix the pipeline if the
+   fixture documents real behavior; fix the expected if you mis-specified.
+
+Never write an `expected.yaml` to match a buggy pipeline.
+
+### Adding or changing a classifier rule
+
+Classifier rules live in `harness/rules.yaml`. Each rule has:
+- `when:` — predicate (AND of keys, plus `any:` / `all:` composition)
+- `unless:` — optional negative predicate
+- `emit:` — what RoutedEvent to produce
+- `contract:` — `must_fire_on` / `must_not_fire_on` fixture references
+
+A rule whose contract fails fails CI. To add a rule:
+
+1. Edit `harness/rules.yaml`.
+2. Reference at least one positive and one negative fixture in `contract:`.
+3. Run `insight-forge eval --verify-contracts`.
+4. Run `pytest tests/test_contracts.py -v` to confirm.
+
+The full rule schema and predicate vocabulary lives in
+[`harness/README.md`](harness/README.md).
+
+### Adding an evidence bundle field
+
+The evidence schema is at `schemas/evidence_bundle.schema.json`. To extend it:
+
+1. Edit the schema (additive changes only — never break existing bundles).
+2. Update `scripts/pipeline.py:write_evidence_bundle()` to populate the field.
+3. Add a unit test in `tests/test_evidence_schema.py`.
+4. Run `insight-forge validate-evidence --evals` — every bundle in the eval
+   suite must still validate.
+
+If a field stores user-quoted text, also extend
+`scripts/validate_evidence.py:verify_traceability()` to check it.
+
+### Editing the YAML lite parser
+
+The fallback YAML parser in `scripts/pipeline.py` is a critical path —
+users without `pyyaml` installed depend on it round-tripping rules.yaml,
+evidence bundles, and observation state correctly.
+
+**Before any change**, run `pytest tests/test_yaml_loader.py -v`. If your
+change is correct, all 17 tests still pass. If you need to add a new edge
+case, add the test first, then make it pass.
+
+## Pull request hygiene
+
+- One PR = one concern. *"feat: thing X + chore: rename Y"* is two PRs.
+- Commits are squashed on merge — your PR title becomes the commit message,
+  so write it as a complete sentence.
+- A PR description should answer: **what changed, why, and how was it tested**.
+- Don't bump version numbers in PRs unless the PR is the release itself.
+
+## Things we don't accept
+
+- Auto-application of any proposal. The user is the only authority that
+  modifies `CLAUDE.md` / `AGENTS.md` or `harness/rules.yaml`.
+- LLM-only mutations without a deterministic baseline path.
+- Removing a closure signal — adding new ones is fine, removing established
+  ones changes the trust contract.
+- Vague counter-evidence. The Devil's Advocate clause must be specific to
+  the claim, not a phrase that's true regardless of project.
+
+## Where to read next
+
+- [`README.md`](README.md) — what the tool does and why
+- [`docs/how-it-works.md`](docs/how-it-works.md) — algorithm walkthrough
+- [`harness/README.md`](harness/README.md) — rule spec and predicate vocabulary
+- [`evals/README.md`](evals/README.md) — fixture format
+- [`harness/proposals/README.md`](harness/proposals/README.md) — proposer output format

--- a/README.md
+++ b/README.md
@@ -138,19 +138,21 @@ Every change runs against four executable contracts. CI ([.github/workflows/eval
 pip install -e ".[dev]"
 
 # 1. Regression evals — 15 fixtures + 1 known gap, false_promotion_rate must stay at 0%
-python3 scripts/run_evals.py
+insight-forge eval
 
 # 2. Harness contracts — every rule's must_fire_on / must_not_fire_on must hold
-python3 scripts/run_evals.py --verify-contracts
+insight-forge eval --verify-contracts
 
-# 3. Unit tests — YAML fallback, harness predicates, evidence schema, contracts
+# 3. Unit tests — YAML fallback, harness predicates, evidence schema, contracts, CLI
 pytest
 
 # 4. Evidence bundles — schema valid AND every quote traceable to its source transcript
-python3 scripts/validate_evidence.py --evals
+insight-forge validate-evidence --evals
 ```
 
 The fourth gate is the one that makes *"every suggestion cites your transcripts"* executable, not a slogan: a bundle with an invented quote fails the build.
+
+The CLI is a thin wrapper — every subcommand maps to one of the existing scripts under `scripts/` (and running `python3 scripts/run_evals.py --verify-contracts` directly stays supported, in particular for the SKILL.md flow which doesn't `pip install`). Run `insight-forge doctor` to diagnose your local environment.
 
 ---
 

--- a/insight_forge/__init__.py
+++ b/insight_forge/__init__.py
@@ -1,0 +1,10 @@
+"""Insight Forge — cross-session ARA-style learner.
+
+This package only houses the CLI entry point. The actual pipeline,
+classifier rules, eval harness, and proposers live in `scripts/` and
+`harness/` to keep the layout script-oriented (the project's house style).
+
+The CLI is a thin dispatcher — it shells out to the existing scripts so
+that running them directly stays the documented, supported way.
+"""
+__version__ = "0.1.0"

--- a/insight_forge/__main__.py
+++ b/insight_forge/__main__.py
@@ -1,0 +1,5 @@
+"""Allow `python -m insight_forge` to invoke the CLI."""
+from insight_forge.cli import main
+
+if __name__ == "__main__":
+    main()

--- a/insight_forge/cli.py
+++ b/insight_forge/cli.py
@@ -1,0 +1,220 @@
+"""
+insight-forge — CLI entry point.
+
+Exposes the most common workflows as named subcommands. The implementation
+is intentionally a thin dispatcher: each subcommand resolves to one of the
+existing scripts under `scripts/` and execs it as a subprocess. This keeps
+the script-oriented layout intact while giving installed users a friendlier
+surface than `python3 scripts/run_evals.py --verify-contracts`.
+
+USAGE:
+    insight-forge                              # default = scan
+    insight-forge scan [--rebuild|--challenge|--since|--fuzzy-cwd|...]
+    insight-forge eval [--fixture|--json|--verify-contracts|--rules-path|...]
+    insight-forge propose [--dry-run|--target-fixture|--max-candidates]
+    insight-forge validate-evidence [BUNDLE] [--evals|--source PATH]
+    insight-forge doctor
+    insight-forge --version
+
+Run `insight-forge <subcommand> --help` to see the underlying script's flags.
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+from insight_forge import __version__
+
+# Resolve scripts/ relative to the repo root, regardless of where the user
+# invokes the CLI from. The repo root is the parent of the `insight_forge`
+# package directory.
+_PACKAGE_DIR = Path(__file__).resolve().parent
+_REPO_ROOT = _PACKAGE_DIR.parent
+SCRIPTS = _REPO_ROOT / "scripts"
+
+
+def _exec_script(script_name: str, passthrough_args: list[str]) -> int:
+    """Run scripts/<name>.py with the user's args, streaming stdout/stderr."""
+    script = SCRIPTS / script_name
+    if not script.exists():
+        print(f"insight-forge: script not found: {script}", file=sys.stderr)
+        return 2
+    cmd = [sys.executable, str(script), *passthrough_args]
+    return subprocess.run(cmd).returncode
+
+
+# ---------------------------------------------------------------------------
+# `doctor` — environment diagnostic. Implemented inline because there's no
+# corresponding script to delegate to.
+# ---------------------------------------------------------------------------
+
+def cmd_doctor(_args: argparse.Namespace) -> int:
+    """Sanity-check the local environment and report status to the user."""
+    rows: list[tuple[str, str, str]] = []  # (label, status, detail)
+
+    py_ver = sys.version_info
+    py_ok = py_ver >= (3, 10)
+    rows.append(("Python", "OK" if py_ok else "FAIL",
+                  f"{py_ver.major}.{py_ver.minor}.{py_ver.micro} "
+                  f"(requires >= 3.10)"))
+
+    try:
+        import yaml  # noqa: F401
+        rows.append(("PyYAML", "OK", "available (fast path)"))
+    except ImportError:
+        rows.append(("PyYAML", "WARN",
+                      "not installed — falls back to lite parser. "
+                      "pip install pyyaml for the fast path"))
+
+    try:
+        import jsonschema  # noqa: F401
+        rows.append(("jsonschema", "OK", "available (evidence validator)"))
+    except ImportError:
+        rows.append(("jsonschema", "WARN",
+                      "not installed — `validate-evidence` will degrade. "
+                      "pip install jsonschema"))
+
+    claude_home = Path(os.environ.get("CLAUDE_HOME", Path.home() / ".claude"))
+    claude_dir = claude_home / "projects"
+    rows.append(("~/.claude/projects",
+                  "OK" if claude_dir.exists() else "WARN",
+                  str(claude_dir) +
+                  (" — exists" if claude_dir.exists()
+                   else " — not found (no Claude Code sessions yet)")))
+
+    codex_home = Path(os.environ.get("CODEX_HOME", Path.home() / ".codex"))
+    codex_dir = codex_home / "sessions"
+    rows.append(("~/.codex/sessions",
+                  "OK" if codex_dir.exists() else "WARN",
+                  str(codex_dir) +
+                  (" — exists" if codex_dir.exists()
+                   else " — not found (no Codex CLI sessions yet)")))
+
+    rules_path = _REPO_ROOT / "harness" / "rules.yaml"
+    rules_ok = rules_path.exists()
+    rules_detail = str(rules_path)
+    if rules_ok:
+        try:
+            sys.path.insert(0, str(_REPO_ROOT))
+            from harness.loader import load_rules  # noqa: E402
+            rs = load_rules(rules_path)
+            rules_detail = f"loaded {len(rs.rules)} rule(s)"
+        except Exception as exc:
+            rules_ok = False
+            rules_detail = f"failed to parse: {exc}"
+    rows.append(("harness/rules.yaml",
+                  "OK" if rules_ok else "FAIL", rules_detail))
+
+    schema_path = _REPO_ROOT / "schemas" / "evidence_bundle.schema.json"
+    rows.append(("evidence schema",
+                  "OK" if schema_path.exists() else "FAIL",
+                  str(schema_path)))
+
+    fixtures_count = len(list((_REPO_ROOT / "evals" / "fixtures").glob("*.jsonl")))
+    rows.append(("evals/fixtures",
+                  "OK" if fixtures_count > 0 else "WARN",
+                  f"{fixtures_count} fixture(s)"))
+
+    last_run = Path.cwd() / ".insight-forge" / ".last_run"
+    if last_run.exists():
+        rows.append(("last run cursor", "OK",
+                      last_run.read_text(encoding="utf-8").splitlines()[0]
+                      if last_run.read_text(encoding="utf-8").strip() else "(empty)"))
+    else:
+        rows.append(("last run cursor", "INFO",
+                      "no .insight-forge/.last_run yet — first run will scan everything"))
+
+    # --- render ----------------------------------------------------------
+    label_w = max(len(r[0]) for r in rows)
+    status_w = 4
+    print()
+    print("  insight-forge — environment diagnostic")
+    print("  " + "─" * 56)
+    overall_ok = True
+    for label, status, detail in rows:
+        mark = {"OK": "✓", "WARN": "⚠", "FAIL": "✗", "INFO": "·"}[status]
+        if status == "FAIL":
+            overall_ok = False
+        print(f"  {mark} {label:<{label_w}} {status:<{status_w}}  {detail}")
+    print()
+    if overall_ok:
+        print("  doctor: ready")
+    else:
+        print("  doctor: at least one critical check failed")
+    print()
+    return 0 if overall_ok else 1
+
+
+# ---------------------------------------------------------------------------
+# Subcommand wiring
+# ---------------------------------------------------------------------------
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="insight-forge",
+        description="Cross-session ARA-style learner. Reads JSONL transcripts "
+                     "from Claude Code or Codex CLI, crystallizes typed "
+                     "knowledge, proposes CLAUDE.md / AGENTS.md diffs.",
+        epilog="Run `insight-forge <subcommand> --help` to see the underlying "
+                "script's flags.",
+    )
+    parser.add_argument("--version", action="version",
+                         version=f"insight-forge {__version__}")
+    sub = parser.add_subparsers(dest="command")
+
+    # `scan` — run.py
+    sub.add_parser("scan", help="scan new sessions, run pipeline, write proposal "
+                                  "(default subcommand)", add_help=False)
+    # `eval` — run_evals.py
+    sub.add_parser("eval", help="run regression evals + contract verifier",
+                    add_help=False)
+    # `propose` — propose_rules.py
+    sub.add_parser("propose", help="propose harness rule edits from known gaps",
+                    add_help=False)
+    # `validate-evidence` — validate_evidence.py
+    sub.add_parser("validate-evidence",
+                    help="validate an evidence bundle against the schema "
+                         "(and optionally against its source transcript)",
+                    add_help=False)
+    # `doctor` — implemented inline
+    sub.add_parser("doctor", help="diagnose the local environment")
+
+    # We parse only argv[0] (the subcommand) here, then forward the rest
+    # untouched to the underlying script's argparse — this preserves every
+    # flag the script supports without redefining it.
+    argv = list(sys.argv[1:] if argv is None else argv)
+    if not argv:
+        argv = ["scan"]
+
+    cmd = argv[0]
+    if cmd in ("-h", "--help"):
+        parser.print_help()
+        return 0
+    if cmd in ("-V", "--version"):
+        print(f"insight-forge {__version__}")
+        return 0
+
+    rest = argv[1:]
+
+    if cmd == "doctor":
+        return cmd_doctor(argparse.Namespace())
+    if cmd == "scan":
+        return _exec_script("run.py", rest)
+    if cmd == "eval":
+        return _exec_script("run_evals.py", rest)
+    if cmd == "propose":
+        return _exec_script("propose_rules.py", rest)
+    if cmd == "validate-evidence":
+        return _exec_script("validate_evidence.py", rest)
+
+    parser.print_usage(sys.stderr)
+    print(f"insight-forge: unknown command: {cmd}", file=sys.stderr)
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,12 +41,18 @@ Homepage = "https://github.com/bacoco/insight-forge"
 Issues = "https://github.com/bacoco/insight-forge/issues"
 Documentation = "https://github.com/bacoco/insight-forge/blob/main/docs/how-it-works.md"
 
+[project.scripts]
+# Installs an `insight-forge` console_scripts entry point. The CLI is a
+# thin wrapper that dispatches to the existing scripts/ — running them
+# directly stays the documented, supported way (and is what SKILL.md
+# uses, since the skill clones the repo rather than pip-installing).
+insight-forge = "insight_forge.cli:main"
+
 [tool.setuptools]
-# Script-oriented project — no python package to ship via setuptools.
-# `pip install -e .` makes the dev workflow ergonomic without forcing a
-# package layout on the codebase.
-py-modules = []
-packages = []
+# Only the small CLI dispatcher package ships with the wheel. The pipeline
+# itself lives in scripts/ and stays script-oriented (the project's house
+# style).
+packages = ["insight_forge"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,112 @@
+"""Tests for insight_forge.cli — the console-scripts entry point.
+
+The CLI is a dispatcher; we test that it correctly routes subcommands to
+the underlying scripts and surfaces help / version / doctor output.
+"""
+from __future__ import annotations
+
+import io
+import sys
+from contextlib import redirect_stderr, redirect_stdout
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from insight_forge import __version__
+from insight_forge.cli import main, _exec_script
+
+
+def _capture(argv):
+    """Run cli.main with stdout/stderr captured."""
+    out = io.StringIO()
+    err = io.StringIO()
+    with redirect_stdout(out), redirect_stderr(err):
+        rc = main(argv)
+    return rc, out.getvalue(), err.getvalue()
+
+
+def test_version_via_flag():
+    rc, out, err = _capture(["--version"])
+    assert rc == 0
+    assert __version__ in out
+
+
+def test_help_short_circuits():
+    rc, out, _ = _capture(["--help"])
+    assert rc == 0
+    assert "scan" in out and "eval" in out and "propose" in out
+
+
+def test_unknown_subcommand_returns_error():
+    rc, _, err = _capture(["wishful-thinking"])
+    assert rc != 0
+    assert "unknown command" in err
+
+
+def test_default_subcommand_is_scan():
+    """Calling `insight-forge` with no args should dispatch to `scan` (run.py).
+    We mock the dispatcher so we don't actually run the pipeline here."""
+    with patch("insight_forge.cli._exec_script") as exec_mock:
+        exec_mock.return_value = 0
+        rc = main([])
+    assert rc == 0
+    assert exec_mock.called
+    args, _ = exec_mock.call_args
+    assert args[0] == "run.py"
+
+
+def test_eval_dispatches_to_run_evals():
+    with patch("insight_forge.cli._exec_script") as exec_mock:
+        exec_mock.return_value = 0
+        rc = main(["eval", "--verify-contracts"])
+    assert rc == 0
+    args, _ = exec_mock.call_args
+    assert args[0] == "run_evals.py"
+    assert args[1] == ["--verify-contracts"]
+
+
+def test_propose_dispatches_to_propose_rules():
+    with patch("insight_forge.cli._exec_script") as exec_mock:
+        exec_mock.return_value = 0
+        rc = main(["propose", "--dry-run"])
+    assert rc == 0
+    args, _ = exec_mock.call_args
+    assert args[0] == "propose_rules.py"
+    assert args[1] == ["--dry-run"]
+
+
+def test_validate_evidence_dispatches():
+    with patch("insight_forge.cli._exec_script") as exec_mock:
+        exec_mock.return_value = 0
+        rc = main(["validate-evidence", "--evals"])
+    assert rc == 0
+    args, _ = exec_mock.call_args
+    assert args[0] == "validate_evidence.py"
+
+
+def test_passthrough_args_preserved():
+    """Flags after the subcommand must reach the underlying script untouched.
+    This is the contract that lets us avoid redefining every script's flags."""
+    with patch("insight_forge.cli._exec_script") as exec_mock:
+        exec_mock.return_value = 0
+        main(["eval", "--fixture", "simple_success", "--json"])
+    args, _ = exec_mock.call_args
+    assert args[1] == ["--fixture", "simple_success", "--json"]
+
+
+def test_doctor_runs_and_returns_int():
+    """doctor is implemented inline (not a subprocess) — verify it runs and
+    produces a status report. Exit code depends on the local environment."""
+    rc, out, _ = _capture(["doctor"])
+    assert isinstance(rc, int)
+    assert "environment diagnostic" in out
+
+
+def test_exec_script_returns_2_for_missing_script(tmp_path, monkeypatch):
+    """If a script is missing, the dispatcher should return exit code 2,
+    not crash."""
+    # Repoint SCRIPTS at a directory with no files so the resolution fails
+    monkeypatch.setattr("insight_forge.cli.SCRIPTS", tmp_path)
+    rc = _exec_script("nonexistent.py", [])
+    assert rc == 2


### PR DESCRIPTION
## Why

Phase-2 step 1 toward the **open-source-readability score** the reviewer flagged at 8/10 (vs 10/10 on the personal-tool scope). The bar: someone landing on the repo from GitHub should be able to install, smoke-test, and contribute without opening Python files first.

Net effect:

\`\`\`bash
pip install -e \".[dev]\"
insight-forge --help
insight-forge doctor
insight-forge eval
insight-forge eval --verify-contracts
insight-forge propose --dry-run
insight-forge validate-evidence --evals
\`\`\`

Every command above works. The four-gate CI now uses the CLI form, so the README's quality-gates section is what users actually run, not a translation.

## What lands

### \`insight_forge/\` — CLI dispatcher package

A minimal package (~180 LOC) that **does not move any pipeline code**. Every subcommand shells out to the existing \`scripts/<name>.py\`:

| Command | Delegates to |
|---|---|
| \`insight-forge scan\` (default) | \`scripts/run.py\` |
| \`insight-forge eval\` | \`scripts/run_evals.py\` |
| \`insight-forge propose\` | \`scripts/propose_rules.py\` |
| \`insight-forge validate-evidence\` | \`scripts/validate_evidence.py\` |
| \`insight-forge doctor\` | inline (Python version, \`~/.claude\` / \`~/.codex\` visibility, PyYAML, jsonschema, \`rules.yaml\` parseability, fixtures count) |

**Passthrough is total** — every flag the underlying script supports is forwarded untouched. The CLI never redefines flags, so the dispatcher never goes out of sync.

### \`pyproject.toml\` — entry point

\`\`\`toml
[project.scripts]
insight-forge = \"insight_forge.cli:main\"

[tool.setuptools]
packages = [\"insight_forge\"]
\`\`\`

Only the CLI dispatcher ships in the wheel. The pipeline stays in \`scripts/\` because (a) \`SKILL.md\` invokes \`python3 scripts/run.py\` directly without a pip install, and (b) the script-oriented layout works fine.

### CI updated to use the CLI

\`\`\`yaml
- run: pip install -e \".[dev]\"
- run: insight-forge --version          # NEW: catches broken entry-point
- run: insight-forge eval
- run: insight-forge eval --verify-contracts
- run: insight-forge propose --dry-run
- run: pytest
- run: insight-forge validate-evidence --evals
\`\`\`

The new CLI smoke test catches packaging mistakes (missing \`__init__.py\`, broken entry point) before the gates that matter.

### \`tests/test_cli.py\` — 10 new tests, 65 total

Covers: \`--version\`, \`--help\`, default subcommand, unknown subcommand, dispatcher routing for each subcommand, passthrough flag preservation, doctor invocation, missing-script error handling. Uses \`unittest.mock.patch\` so dispatcher tests don't actually spawn subprocesses.

### \`CONTRIBUTING.md\` — onboarding doc

Documents: setup, the four quality gates, how to add a fixture / rule / evidence bundle field, how to edit the YAML lite parser without breaking it, PR hygiene, things we don't accept (auto-application, vague counter-evidence), and where to read next.

### \`README.md\`

The Quality gates section now uses \`insight-forge eval\` etc. A note clarifies that the script form (\`python3 scripts/run_evals.py\`) is still supported — which is required, because that's how SKILL.md invokes the pipeline.

## Out of scope

- No pipeline refactor.
- No \`SKILL.md\` changes — the skill flow still calls \`python3 scripts/run.py\`.
- No \`CHANGELOG.md\` (next PR — phase 2 step 3, build discipline).
- No privacy/redaction (next PR — phase 2 step 2).

## Test plan

- [x] \`pytest\`: 65 passed in 0.17s (was 55, +10 CLI tests)
- [x] \`insight-forge eval\`: 15/15 fixtures pass, false_promotion_rate=0%
- [x] \`insight-forge eval --verify-contracts\`: all rule contracts hold
- [x] \`insight-forge propose --dry-run\`: identifies \`il faut toujours\` (score=1, 0 régressions)
- [x] \`insight-forge validate-evidence --evals\`: all 6 bundles valid (schema + traceability)
- [x] \`insight-forge doctor\`: correctly reports local Python 3.9 as FAIL (CI matrix covers 3.10/3.11/3.12)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced `insight-forge` CLI command with subcommands: `eval`, `propose`, `validate-evidence`, and `doctor`.
  * Added `doctor` diagnostic command for environment validation and health checks.

* **Documentation**
  * Expanded contribution guidelines covering setup, quality gates, and common workflows.
  * Updated README with new CLI command references.

* **Chores**
  * Updated CI workflow to use new CLI commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->