### PR TITLE
feat: near-duplicate detection in proposals (anti-bloat, no LLM)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,26 @@ All notable changes to this project are documented in this file. The format is b
 
 ## [Unreleased]
 
+### Added
+
+- **Near-duplicate detection in proposals.** New `scripts/similarity.py`
+  with token-level Jaccard + subset-relation checks. The proposer now
+  annotates each entry with a `⚠ Possibly redundant: <id>` line when a
+  near-duplicate exists in the same layer or in the project's existing
+  `CLAUDE.md` / `AGENTS.md`. Friendly stderr summary surfaces the count.
+  Conservative by design: stopwords (EN + FR) are filtered, one-letter
+  tokens dropped, and the proposer never removes or hides any entry —
+  the annotation is a suggestion the user reviews.
+- New eval fixture `near_duplicate_heuristic` (two sessions producing
+  near-duplicate heuristics) + 26 unit tests in `test_similarity.py` +
+  3 integration tests in `test_propose_claude_md.py`.
+
+### Fixed
+
+- `propose_claude_md.py:filter_recent` no longer raises
+  `UnboundLocalError` when PyYAML's alphabetically-sorted output places
+  `date:` before `id:` in `trace/session_index.yaml` (issue #30).
+
 ## [0.1.0] — 2026-05-05
 
 First tagged version. The project is shippable as a personal tool with full executable

--- a/evals/expected/near_duplicate_heuristic.expected.yaml
+++ b/evals/expected/near_duplicate_heuristic.expected.yaml
@@ -1,0 +1,27 @@
+# Two sessions, two near-duplicate heuristics. Both crystallize via
+# verbal-affirmation. The pipeline doesn't dedupe (each session's promotion
+# is independent — duplicates are expected to surface).
+#
+# What the eval harness asserts here is the pipeline-level behavior:
+# 2 heuristics get cristallized, 2 evidence bundles, all quotes traceable.
+# The "this looks like a duplicate" annotation lives in the proposal layer
+# and is exercised by tests/test_propose_claude_md.py (integration test).
+crystallized:
+  total: 2
+  by_layer:
+    heuristic: 2
+    claim: 0
+    dead_end: 0
+    constraint: 0
+    concept: 0
+staged_only: 0
+expected_signals:
+  - verbal-affirmation
+must_have_evidence_bundle: true
+must_have_counter_evidence: true
+notes: |
+  This fixture is the regression test for near-duplicate annotation. Two
+  sessions independently crystallize the same project rule ("Always use
+  pnpm not npm"). Both promotions are correct in isolation — what's
+  redundant is the resulting CLAUDE.md proposal, which is where the
+  similarity check fires.

--- a/evals/fixtures/near_duplicate_heuristic.jsonl
+++ b/evals/fixtures/near_duplicate_heuristic.jsonl
@@ -1,0 +1,10 @@
+{"_marker": "session_start", "session_id": "ndh10001-0000-0000-0000-00000000001a", "session_short": "ndh10001", "agent": "claude", "mtime": "2026-05-03T10:00:00", "size_kb": 3}
+{"role": "user", "content": "Always use pnpm not npm in this repo for package management.", "timestamp": "2026-05-03T10:00:05", "session_id": "ndh10001-0000-0000-0000-00000000001a", "session_short": "ndh10001", "agent": "claude"}
+{"role": "assistant", "content": "Got it.", "timestamp": "2026-05-03T10:00:10", "session_id": "ndh10001-0000-0000-0000-00000000001a", "session_short": "ndh10001", "agent": "claude"}
+{"role": "user", "content": "yes parfait", "timestamp": "2026-05-03T10:00:20", "session_id": "ndh10001-0000-0000-0000-00000000001a", "session_short": "ndh10001", "agent": "claude"}
+{"_marker": "session_end"}
+{"_marker": "session_start", "session_id": "ndh20002-0000-0000-0000-00000000001b", "session_short": "ndh20002", "agent": "claude", "mtime": "2026-05-04T10:00:00", "size_kb": 3}
+{"role": "user", "content": "Always use pnpm in this repo, never npm.", "timestamp": "2026-05-04T10:00:05", "session_id": "ndh20002-0000-0000-0000-00000000001b", "session_short": "ndh20002", "agent": "claude"}
+{"role": "assistant", "content": "OK.", "timestamp": "2026-05-04T10:00:10", "session_id": "ndh20002-0000-0000-0000-00000000001b", "session_short": "ndh20002", "agent": "claude"}
+{"role": "user", "content": "exact, c'est ça la règle", "timestamp": "2026-05-04T10:00:20", "session_id": "ndh20002-0000-0000-0000-00000000001b", "session_short": "ndh20002", "agent": "claude"}
+{"_marker": "session_end"}

--- a/harness/README.md
+++ b/harness/README.md
@@ -169,6 +169,36 @@ seam — an LLM-based generator can replace it without touching the
 sandboxing or scoring code. See `harness/proposals/README.md` for the
 proposal file format and how to apply one.
 
+## Avoiding bloat — near-duplicate detection in proposals
+
+The conservative-by-default contract protects against *over-confident*
+promotion. It does **not** protect against *redundant* promotion — two
+sessions independently confirming the same rule produce two crystallized
+entries, and without intervention both end up in the proposal markdown.
+
+`scripts/similarity.py` adds a deterministic check (no LLM) that runs at
+proposal time. For each entry, the proposer compares against:
+
+1. Other entries in the same layer (heuristics vs heuristics, etc.)
+2. Lines in the existing `CLAUDE.md` / `AGENTS.md` at the project root,
+   if either file is present.
+
+When token-Jaccard similarity passes the threshold (default 0.6) **or** a
+subset relation fires, the entry gets a `⚠ Possibly redundant: ...` line
+in the rendered proposal. The friendly stderr summary surfaces the count
+(`⚠ 2 possible redundancy warnings in this proposal`) so the user
+notices before pasting.
+
+The check is conservative — false positives are worse than false negatives
+because a noisy detector trains users to ignore the warning. Stopwords
+are filtered (English + French function words), one-letter tokens are
+dropped, and short markdown lines are skipped to avoid matching headers.
+
+The proposer **never** removes, merges, or hides an entry. The annotation
+is a suggestion the user reviews; the human decides whether to merge,
+replace, keep both, or do something else entirely. Same conservative
+contract as the rest of the project.
+
 ## Marking a known gap
 
 Add to `evals/expected/<fixture>.expected.yaml`:

--- a/scripts/propose_claude_md.py
+++ b/scripts/propose_claude_md.py
@@ -167,6 +167,109 @@ def filter_recent(entries: list[dict], since: datetime, sessions_index_path: Pat
     return kept
 
 
+def _entry_text_for_similarity(e: dict, prefix: str) -> str:
+    """Pick the field that best captures what the entry means.
+
+    For heuristics we want the rule text; for claims, the statement; for
+    dead ends, the lesson + avoid signal. Falls back to the title when
+    the structured field is missing.
+    """
+    if prefix == "H":
+        return e.get("Rule") or e.get("title") or ""
+    if prefix == "C":
+        return e.get("Statement") or e.get("title") or ""
+    if prefix == "D":
+        lesson = e.get("Lesson") or ""
+        avoid = e.get("Avoid signal") or ""
+        return f"{avoid} {lesson}".strip() or e.get("title") or ""
+    return e.get("title") or ""
+
+
+def _entry_session(e: dict) -> str:
+    """Extract the first session id from the `Sessions: [a, b]` field."""
+    sessions_field = e.get("Sessions", "")
+    ids = re.findall(r"[a-f0-9]{4,}", sessions_field)
+    return ids[0] if ids else ""
+
+
+def _read_target_md_lines(forge_dir: Path) -> list[str]:
+    """Best-effort: read CLAUDE.md / AGENTS.md from project root for
+    cross-comparison against incoming entries. Empty list if neither
+    exists or both fail to read."""
+    project_root = forge_dir.parent
+    out: list[str] = []
+    for name in ("CLAUDE.md", "AGENTS.md"):
+        p = project_root / name
+        if not p.exists():
+            continue
+        try:
+            for line in p.read_text(encoding="utf-8").splitlines():
+                s = line.strip()
+                if s and len(s) > 20:
+                    out.append(s)
+        except Exception:
+            pass
+    return out
+
+
+def _near_duplicate_annotation(forge_dir: Path, entry: dict, prefix: str,
+                                same_layer_entries: list[dict]) -> str:
+    """Compute the optional `⚠ Possibly redundant: ...` markdown line for
+    one entry. Empty string when no near-duplicate is found.
+
+    Two passes:
+      1. Compare against other crystallized entries in the same layer
+         (catches duplicates produced across multiple sessions).
+      2. Compare against existing CLAUDE.md / AGENTS.md lines in the
+         project root (catches drift between proposals and what the user
+         already has).
+    """
+    sys.path.insert(0, str(Path(__file__).resolve().parent))
+    from similarity import (find_near_duplicates,  # noqa: E402
+                              find_near_duplicates_in_text)
+
+    cand_text = _entry_text_for_similarity(entry, prefix)
+    if not cand_text:
+        return ""
+
+    cand_id = entry.get("id", "")
+    cand_session = _entry_session(entry)
+
+    siblings = [
+        {
+            "id": e.get("id", ""),
+            "text": _entry_text_for_similarity(e, prefix),
+            "session": _entry_session(e),
+        }
+        for e in same_layer_entries
+        if e.get("id") and e.get("id") != cand_id
+    ]
+    sibling_matches = find_near_duplicates(
+        candidate_text=cand_text,
+        candidate_id=cand_id,
+        candidate_session=cand_session,
+        existing_entries=siblings,
+    )
+
+    chunks: list[str] = []
+    for m in sibling_matches[:2]:  # cap at 2 — long lists become noise
+        chunks.append(
+            f"  - ⚠ *Possibly redundant*: {m['id']} "
+            f"(token overlap {m['similarity']}, {m['reason']})\n"
+        )
+
+    target_lines = _read_target_md_lines(forge_dir)
+    if target_lines:
+        target_matches = find_near_duplicates_in_text(cand_text, target_lines)
+        for m in target_matches:
+            chunks.append(
+                f"  - ⚠ *Already in your CLAUDE.md / AGENTS.md*: "
+                f"\"{m['line']}\" (token overlap {m['similarity']})\n"
+            )
+
+    return "".join(chunks)
+
+
 def build_proposal(forge_dir: Path, target: str, agent_name: str,
                     since: datetime = None) -> str:
     """Compose the proposal markdown."""
@@ -201,6 +304,7 @@ def build_proposal(forge_dir: Path, target: str, agent_name: str,
             sessions = h.get("Sessions", "[]")
             out.append(f"- **{h['id']}**: {rule}\n")
             out.append(_bundle_quotes(forge_dir, h["id"]))
+            out.append(_near_duplicate_annotation(forge_dir, h, "H", heuristics))
             if counter and counter != "not_explored":
                 out.append(f"  - *Caveat*: {counter}\n")
             out.append(f"  - *Sessions*: {sessions}\n\n")
@@ -214,6 +318,7 @@ def build_proposal(forge_dir: Path, target: str, agent_name: str,
             sessions = c.get("Sessions", "[]")
             out.append(f"- **{c['id']}** *({status})*: {stmt}\n")
             out.append(_bundle_quotes(forge_dir, c["id"]))
+            out.append(_near_duplicate_annotation(forge_dir, c, "C", claims))
             if counter and counter != "not_explored":
                 out.append(f"  - *Counter-evidence*: {counter}\n")
             out.append(f"  - *Sessions*: {sessions}\n\n")
@@ -227,6 +332,7 @@ def build_proposal(forge_dir: Path, target: str, agent_name: str,
             sessions = d.get("Sessions", "[]")
             out.append(f"- **{d['id']}**: avoid {avoid}\n")
             out.append(_bundle_quotes(forge_dir, d["id"]))
+            out.append(_near_duplicate_annotation(forge_dir, d, "D", dead_ends))
             if lesson:
                 out.append(f"  - *Lesson*: {lesson}\n")
             if could and could != "not_explored":
@@ -419,6 +525,21 @@ def _print_summary(forge_dir: Path, out_path: Path, target: str, since) -> None:
     if staged_pending:
         sys.stderr.write(f"  · {staged_pending} observation{'s' if staged_pending != 1 else ''} "
                          f"still in staging (need more sessions)\n")
+
+    # Count "Possibly redundant" annotations in the proposal so the user
+    # notices the bloat warning without having to open the file.
+    try:
+        proposal_text = out_path.read_text(encoding="utf-8")
+        redundant_count = proposal_text.count("⚠ *Possibly redundant*")
+        already_in_count = proposal_text.count("⚠ *Already in your")
+        if redundant_count or already_in_count:
+            sys.stderr.write(
+                f"  ⚠ {redundant_count + already_in_count} possible redundancy "
+                f"warning{'s' if redundant_count + already_in_count != 1 else ''} "
+                f"in this proposal — review before pasting\n"
+            )
+    except Exception:
+        pass
 
     sys.stderr.write("\n")
     sys.stderr.write(f"  Full proposal — open or paste from:\n")

--- a/scripts/similarity.py
+++ b/scripts/similarity.py
@@ -1,0 +1,179 @@
+"""
+Insight Forge — token-level similarity for near-duplicate detection.
+
+Used by `propose_claude_md.py` to flag entries that look redundant against
+each other or against an existing CLAUDE.md / AGENTS.md, **before** they
+reach a copy-paste block. The point is to keep the harness from growing
+unnecessarily — same conservative spirit as the rest of the project, just
+applied to growth instead of promotion.
+
+This module is **deterministic**. No LLM. The signals it surfaces are:
+
+  - Jaccard similarity on lowercased tokens (with light stopword filtering)
+  - Subset relations ("rule A's tokens are mostly contained in rule B")
+
+Either signal is a *suggestion* the user should verify, never an
+auto-action. The proposal markdown gets a `⚠ Possibly redundant: ...`
+annotation; the user decides whether to merge / replace / keep both.
+"""
+from __future__ import annotations
+
+import re
+
+_TOKEN_RE = re.compile(r"\w+", re.UNICODE)
+
+# Conservative stopword set. Trimming these prevents two unrelated rules
+# from looking similar just because they share function words ("the", "is",
+# "le", "la"). Both EN and FR — the project is bilingual.
+_STOPWORDS: frozenset[str] = frozenset({
+    # English
+    "the", "a", "an", "is", "are", "was", "were", "be", "been", "being",
+    "to", "of", "in", "on", "at", "for", "with", "by", "from", "as",
+    "and", "or", "but", "not", "no", "yes", "if", "then", "else",
+    "i", "you", "he", "she", "it", "we", "they", "them", "us",
+    "this", "that", "these", "those", "there", "here", "where", "when",
+    "do", "does", "did", "have", "has", "had", "will", "would", "should",
+    "must", "may", "can", "could", "shall", "ought",
+    # French
+    "le", "la", "les", "un", "une", "des", "du", "de", "d", "l",
+    "et", "ou", "mais", "ne", "pas", "que", "qui", "quoi",
+    "ce", "cette", "ces", "cela", "ça", "ca",
+    "il", "elle", "ils", "elles", "on", "nous", "vous",
+    "est", "sont", "était", "ait", "soit",
+    "à", "au", "aux", "en", "par", "pour", "sur", "sous", "avec", "sans",
+    "tu", "moi", "toi", "lui", "leur", "leurs",
+    "se", "s", "son", "sa", "ses", "mon", "ma", "mes", "ton", "ta", "tes",
+})
+
+
+def tokenize(text: str) -> set[str]:
+    """Lowercase, split into word tokens, drop stopwords + 1-letter tokens."""
+    if not text:
+        return set()
+    tokens = _TOKEN_RE.findall(text.lower())
+    return {t for t in tokens if t not in _STOPWORDS and len(t) > 1}
+
+
+def jaccard(text_a: str, text_b: str) -> float:
+    """Token-level Jaccard similarity. 0.0 = disjoint, 1.0 = identical."""
+    a = tokenize(text_a)
+    b = tokenize(text_b)
+    if not a and not b:
+        return 1.0
+    if not a or not b:
+        return 0.0
+    return len(a & b) / len(a | b)
+
+
+def is_subset_of(short: str, long: str, threshold: float = 0.85) -> bool:
+    """True when `short`'s tokens are mostly contained in `long`.
+
+    Distinct from Jaccard because a short rule that's fully covered by a
+    long rule shouldn't get penalized for the long rule's extra detail —
+    the relation we want to surface is "the long version supersedes the
+    short version", not "they look superficially similar."
+    """
+    a = tokenize(short)
+    b = tokenize(long)
+    if not a:
+        return False
+    return len(a & b) / len(a) >= threshold
+
+
+def find_near_duplicates(
+    candidate_text: str,
+    candidate_id: str,
+    candidate_session: str,
+    existing_entries: list[dict],
+    threshold: float = 0.6,
+) -> list[dict]:
+    """Compare candidate against every existing entry. Return matches.
+
+    `existing_entries` is a list of dicts with at least:
+      - `id`: the entry's stable identifier (H01, C03, ...)
+      - `text`: the rule / claim / lesson text to compare against
+      - `session` (optional): short session ID
+
+    A match dict contains:
+      - `id`: matched entry's id
+      - `similarity`: Jaccard score, rounded to 2 decimals
+      - `reason`: short human-readable rationale ("near-identical wording",
+                  "supersedes existing", "high token overlap", ...)
+
+    Sorted by similarity descending. Empty list when nothing matches.
+    """
+    matches: list[dict] = []
+
+    for ex in existing_entries:
+        ex_id = ex.get("id")
+        if not ex_id or ex_id == candidate_id:
+            continue  # don't compare an entry to itself
+        ex_text = ex.get("text") or ""
+
+        score = jaccard(candidate_text, ex_text)
+        # Subset signals are independent: a short rule fully contained in
+        # a long one (or vice versa) is redundant even when Jaccard is low,
+        # because the long rule's extra tokens drag the union down.
+        sub_a = is_subset_of(candidate_text, ex_text)
+        sub_b = is_subset_of(ex_text, candidate_text)
+        if score < threshold and not sub_a and not sub_b:
+            continue
+
+        reasons: list[str] = []
+        if score >= 0.9:
+            reasons.append("near-identical wording")
+        elif sub_b:
+            reasons.append("expanded form of existing")
+        elif sub_a:
+            reasons.append("supersedes existing")
+        else:
+            reasons.append("high token overlap")
+
+        if (candidate_session and ex.get("session")
+                and candidate_session == ex.get("session")):
+            reasons.append("same source session")
+
+        matches.append({
+            "id": ex_id,
+            "similarity": round(score, 2),
+            "reason": "; ".join(reasons),
+        })
+
+    matches.sort(key=lambda m: -m["similarity"])
+    return matches
+
+
+def find_near_duplicates_in_text(
+    candidate_text: str,
+    text_lines: list[str],
+    threshold: float = 0.6,
+    min_line_chars: int = 20,
+) -> list[dict]:
+    """Compare candidate against free-form text lines (e.g. CLAUDE.md).
+
+    Returns up to one best match per call (the highest-overlap line).
+    Lines shorter than `min_line_chars` after stripping are ignored —
+    short lines are usually section headers or stubs, not rules.
+    """
+    best = None
+    for raw in text_lines:
+        line = raw.strip()
+        # Strip common markdown bullet/heading markers before scoring.
+        cleaned = re.sub(r"^(\s*[-*+]\s+|\s*#+\s+)", "", line)
+        if len(cleaned) < min_line_chars:
+            continue
+        score = jaccard(candidate_text, cleaned)
+        # Same subset-signal acceptance as find_near_duplicates: a short
+        # candidate fully contained in a long line still flags.
+        sub_a = is_subset_of(candidate_text, cleaned)
+        sub_b = is_subset_of(cleaned, candidate_text)
+        if score < threshold and not sub_a and not sub_b:
+            continue
+        if best is None or score > best["similarity"]:
+            best = {
+                "line": cleaned[:120],
+                "similarity": round(score, 2),
+                "reason": ("near-identical wording" if score >= 0.9
+                           else "high token overlap"),
+            }
+    return [best] if best else []

--- a/tests/test_propose_claude_md.py
+++ b/tests/test_propose_claude_md.py
@@ -127,3 +127,73 @@ def test_filter_recent_handles_unparseable_date_silently(tmp_path):
     result = filter_recent([_ENTRY], since, sidx)
     # No usable recent IDs → entries returned unchanged.
     assert result == [_ENTRY]
+
+
+# --- near-duplicate annotation in proposals ----------------------------
+
+import subprocess
+import sys
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def _run_pipeline_then_propose(fixture_path: Path, forge_dir: Path) -> str:
+    """Run the full pipeline + proposer on a fixture, return proposal text."""
+    pipeline = REPO_ROOT / "scripts" / "pipeline.py"
+    propose = REPO_ROOT / "scripts" / "propose_claude_md.py"
+
+    res = subprocess.run(
+        [sys.executable, str(pipeline),
+          "--input", str(fixture_path),
+          "--forge-dir", str(forge_dir)],
+        capture_output=True, text=True,
+    )
+    assert res.returncode == 0, f"pipeline failed: {res.stderr}"
+
+    res = subprocess.run(
+        [sys.executable, str(propose), "--forge-dir", str(forge_dir)],
+        capture_output=True, text=True,
+    )
+    assert res.returncode == 0, f"propose failed: {res.stderr}"
+
+    proposal_path = Path(res.stdout.strip())
+    return proposal_path.read_text(encoding="utf-8")
+
+
+def test_proposal_flags_near_duplicate_heuristics(tmp_path):
+    """The near_duplicate_heuristic fixture produces two heuristics about
+    pnpm vs npm. The proposal should annotate the second one with a
+    'Possibly redundant' marker pointing at the first."""
+    fixture = REPO_ROOT / "evals" / "fixtures" / "near_duplicate_heuristic.jsonl"
+    proposal = _run_pipeline_then_propose(fixture, tmp_path / ".forge")
+    assert "⚠ *Possibly redundant*" in proposal, (
+        "Proposal did not flag the near-duplicate. Got:\n" + proposal[:2000]
+    )
+
+
+def test_proposal_does_not_flag_unrelated_entries(tmp_path):
+    """The simple_success fixture produces exactly one heuristic. There's
+    nothing to be redundant with — the proposal must NOT contain a
+    'Possibly redundant' annotation."""
+    fixture = REPO_ROOT / "evals" / "fixtures" / "simple_success.jsonl"
+    proposal = _run_pipeline_then_propose(fixture, tmp_path / ".forge")
+    assert "⚠ *Possibly redundant*" not in proposal
+
+
+def test_proposal_flags_against_existing_claude_md(tmp_path):
+    """When a CLAUDE.md sits at the project root with a rule similar to a
+    newly-crystallized one, the proposal should call it out so the user
+    doesn't paste a duplicate on top of an existing one."""
+    fixture = REPO_ROOT / "evals" / "fixtures" / "simple_success.jsonl"
+    forge_dir = tmp_path / ".insight-forge"
+    project_root = tmp_path  # project root = parent of forge_dir
+    (project_root / "CLAUDE.md").write_text(
+        "# Project rules\n\n"
+        "- Always use pnpm in this repo, never use npm.\n",
+        encoding="utf-8",
+    )
+    proposal = _run_pipeline_then_propose(fixture, forge_dir)
+    assert "⚠ *Already in your" in proposal, (
+        "Proposal did not flag the existing CLAUDE.md line. Got:\n"
+        + proposal[:2000]
+    )

--- a/tests/test_similarity.py
+++ b/tests/test_similarity.py
@@ -1,0 +1,264 @@
+"""Tests for scripts/similarity.py — token similarity primitives.
+
+These tests pin the conservative behavior we want: high Jaccard signals
+near-duplicates, low Jaccard leaves things alone, the function never
+treats two distinct rules as redundant just because they share function
+words. False positives are worse than false negatives — a noisy detector
+trains users to ignore the warning.
+"""
+from __future__ import annotations
+
+import pytest
+
+from similarity import (find_near_duplicates,
+                          find_near_duplicates_in_text,
+                          is_subset_of,
+                          jaccard,
+                          tokenize)
+
+
+# --- tokenize ----------------------------------------------------------
+
+def test_tokenize_basic():
+    assert tokenize("Use pnpm not npm") == {"use", "pnpm", "npm"}
+
+
+def test_tokenize_strips_french_stopwords():
+    assert tokenize("Il faut toujours utiliser pnpm") == {"faut", "toujours", "utiliser", "pnpm"}
+
+
+def test_tokenize_strips_english_stopwords():
+    """Function words ('the', 'is', 'to', 'in') drop out so two rules
+    don't look similar just because they share connectors."""
+    assert tokenize("The api is in the docs") == {"api", "docs"}
+
+
+def test_tokenize_drops_one_letter_tokens():
+    """'a', 'i', 'l' etc. are noise."""
+    assert "a" not in tokenize("a b cd ef")
+    assert "i" not in tokenize("a i u")
+
+
+def test_tokenize_empty():
+    assert tokenize("") == set()
+    assert tokenize(None) == set()
+
+
+# --- jaccard -----------------------------------------------------------
+
+def test_jaccard_identical_strings():
+    assert jaccard("use pnpm", "use pnpm") == 1.0
+
+
+def test_jaccard_disjoint_strings():
+    assert jaccard("use pnpm", "deploy nginx") == 0.0
+
+
+def test_jaccard_partial_overlap():
+    """Two rules saying the same thing in different word order should score
+    high. Order doesn't matter for token-level Jaccard."""
+    a = "Always use pnpm not npm in this repo"
+    b = "Always use pnpm in this repo, never npm"
+    assert jaccard(a, b) > 0.7
+
+
+def test_jaccard_unrelated_rules_score_low():
+    """Rules about different topics must NOT cross-flag, even if they
+    happen to use a common verb."""
+    a = "Always use pnpm for package management"
+    b = "Always run lint:fix before committing"
+    assert jaccard(a, b) < 0.4
+
+
+def test_jaccard_handles_empty():
+    assert jaccard("", "") == 1.0    # both empty = trivially "same"
+    assert jaccard("", "anything") == 0.0
+    assert jaccard("anything", "") == 0.0
+
+
+def test_jaccard_stopwords_dont_inflate_score():
+    """Without stopword filtering, two rules sharing 'the is in' would look
+    similar. With it, they shouldn't."""
+    a = "the api is in production"
+    b = "the bug is in the parser"
+    assert jaccard(a, b) < 0.3
+
+
+# --- is_subset_of ------------------------------------------------------
+
+def test_subset_short_inside_long():
+    assert is_subset_of("use pnpm", "always use pnpm in this repo")
+
+
+def test_subset_distinct_rules_not_subset():
+    assert not is_subset_of("use pnpm", "deploy nginx")
+
+
+def test_subset_partial_overlap_below_threshold():
+    """50% overlap with default threshold of 0.85 should be False."""
+    assert not is_subset_of("use pnpm always", "use yarn always")
+
+
+def test_subset_empty_short_returns_false():
+    """If `short` has no meaningful tokens, claiming subset would be a
+    vacuous truth — explicitly avoid it."""
+    assert not is_subset_of("the the the", "any text here")
+
+
+# --- find_near_duplicates ---------------------------------------------
+
+def test_no_existing_entries_no_matches():
+    assert find_near_duplicates(
+        candidate_text="Always use pnpm",
+        candidate_id="H01",
+        candidate_session="abc12345",
+        existing_entries=[],
+    ) == []
+
+
+def test_finds_high_overlap_match():
+    """Two heuristics about the same thing in different word orders."""
+    existing = [
+        {"id": "H01", "text": "Use pnpm not npm",
+          "session": "aaaa1111"},
+    ]
+    result = find_near_duplicates(
+        candidate_text="Always use pnpm in this repo, never npm",
+        candidate_id="H02",
+        candidate_session="bbbb2222",
+        existing_entries=existing,
+    )
+    assert len(result) == 1
+    assert result[0]["id"] == "H01"
+    # The match arrives via subset signal (H01's tokens are a subset of
+    # the candidate's tokens), so the raw Jaccard can be lower than the
+    # default 0.6 threshold — we only assert the match was found and
+    # carries an actionable reason.
+    assert result[0]["similarity"] > 0
+    assert result[0]["reason"]
+
+
+def test_skips_self_comparison():
+    """An entry should never be compared to itself by ID."""
+    existing = [{"id": "H01", "text": "Use pnpm", "session": "x"}]
+    result = find_near_duplicates(
+        candidate_text="Use pnpm",
+        candidate_id="H01",
+        candidate_session="x",
+        existing_entries=existing,
+    )
+    assert result == []
+
+
+def test_unrelated_entries_not_flagged():
+    existing = [
+        {"id": "H01", "text": "Always run lint:fix before committing",
+          "session": "aaaa1111"},
+        {"id": "H02", "text": "Tests live in tests/, not __tests__/",
+          "session": "bbbb2222"},
+    ]
+    result = find_near_duplicates(
+        candidate_text="Use pnpm not npm",
+        candidate_id="H99",
+        candidate_session="cccc3333",
+        existing_entries=existing,
+    )
+    assert result == []
+
+
+def test_results_sorted_by_similarity_desc():
+    existing = [
+        {"id": "H01", "text": "Use pnpm", "session": "a"},
+        {"id": "H02", "text": "Use pnpm always never npm in repo", "session": "b"},
+    ]
+    result = find_near_duplicates(
+        candidate_text="Use pnpm always never npm in this repo",
+        candidate_id="H99",
+        candidate_session="z",
+        existing_entries=existing,
+    )
+    assert result[0]["id"] == "H02"  # higher overlap
+
+
+def test_same_session_flagged_in_reason():
+    """When two crystallized entries trace back to the same session, the
+    annotation says so — same-session duplicates are stronger evidence
+    of redundancy than independent crystallizations."""
+    existing = [
+        {"id": "H01", "text": "Use pnpm not npm in this repo",
+          "session": "aaaa1111"},
+    ]
+    result = find_near_duplicates(
+        candidate_text="Always use pnpm in this repo, never npm",
+        candidate_id="H02",
+        candidate_session="aaaa1111",  # same session
+        existing_entries=existing,
+    )
+    assert "same source session" in result[0]["reason"]
+
+
+def test_supersedes_existing_when_candidate_extends():
+    """If the new entry is a strict expansion of the old one, the reason
+    should reflect that."""
+    existing = [{"id": "H01", "text": "Use pnpm", "session": "a"}]
+    result = find_near_duplicates(
+        candidate_text="Use pnpm always in this repo",
+        candidate_id="H02",
+        candidate_session="b",
+        existing_entries=existing,
+    )
+    # H01 ⊂ H02 — the new H02 is the "expanded form" of existing H01
+    assert "expanded form" in result[0]["reason"] \
+        or "supersedes" in result[0]["reason"] \
+        or "near-identical" in result[0]["reason"]
+
+
+# --- find_near_duplicates_in_text -------------------------------------
+
+def test_text_lines_match_candidate():
+    lines = [
+        "## Project rules",                # too short / heading — skipped
+        "- Always use pnpm in this repo, never npm.",
+        "- Tests live in tests/, not __tests__/",
+    ]
+    result = find_near_duplicates_in_text(
+        candidate_text="Use pnpm not npm",
+        text_lines=lines,
+    )
+    assert len(result) == 1
+    assert result[0]["similarity"] >= 0.5
+
+
+def test_text_lines_no_match():
+    lines = ["- Deploy with kubectl apply"]
+    result = find_near_duplicates_in_text(
+        candidate_text="Use pnpm not npm",
+        text_lines=lines,
+    )
+    assert result == []
+
+
+def test_text_lines_skips_short_lines():
+    """Short lines are usually headers / stubs and would noisily match
+    almost anything via stopword removal — skip them."""
+    lines = ["pnpm", "use", "- short"]  # all under 20 chars
+    result = find_near_duplicates_in_text(
+        candidate_text="Use pnpm not npm",
+        text_lines=lines,
+    )
+    assert result == []
+
+
+def test_text_lines_returns_only_best_match():
+    """The function returns one summary, not every line — proposals get
+    annotated with a single 'closest existing' line, not a wall of
+    near-misses."""
+    lines = [
+        "- Always use pnpm not npm in this repo",
+        "- Use pnpm everywhere instead of npm and yarn",
+    ]
+    result = find_near_duplicates_in_text(
+        candidate_text="Use pnpm not npm",
+        text_lines=lines,
+    )
+    assert len(result) == 1


### PR DESCRIPTION
## Why

Closes the addition-bias gap from the *subtractive mode* suggestion. The conservative-by-default contract today protects against **over-confident promotion** but not against **redundant promotion** — two sessions independently confirming the same rule produced two crystallized entries that both ended up in the proposal markdown with zero signal to the user that they were near-duplicates.

This PR adds that signal — deterministically, without LLM, without ever removing or hiding any entry. Same conservative contract: the human is the only authority that decides what to merge.

## What you'll see now

Two sessions producing similar pnpm/npm heuristics:

\`\`\`markdown
### Heuristics (project rules)

- **H01**: Always use pnpm not npm in this repo for package management.
  - *You said* (2026-05-03): \"Always use pnpm not npm in this repo for package management.\"
  - *You confirmed* (2026-05-03): \"yes parfait\"
  - ⚠ *Possibly redundant*: H02 (token overlap 0.62, high token overlap)
  - *Sessions*: [ndh10001]

- **H02**: Always use pnpm in this repo, never npm.
  - *You said* (2026-05-04): \"Always use pnpm in this repo, never npm.\"
  - *You confirmed* (2026-05-04): \"exact, c'est ça la règle\"
  - ⚠ *Possibly redundant*: H01 (token overlap 0.62, high token overlap)
  - *Sessions*: [ndh20002]
\`\`\`

Friendly stderr summary surfaces the count so the user notices without opening the file:

\`\`\`text
✓ 2 project rules ready
    • Always use pnpm not npm in this repo for package management.
    • Always use pnpm in this repo, never npm.
⚠ 2 possible redundancy warnings in this proposal — review before pasting
\`\`\`

## What lands

### \`scripts/similarity.py\` — pure functions

| Function | Returns | Purpose |
|---|---|---|
| \`tokenize(text)\` | \`set[str]\` | lowercase + drop EN/FR stopwords + drop 1-char tokens |
| \`jaccard(a, b)\` | \`float\` in [0, 1] | token-level Jaccard similarity |
| \`is_subset_of(short, long)\` | \`bool\` | one-way containment, threshold 0.85 |
| \`find_near_duplicates(cand, existing[])\` | \`list[dict]\` | matches with id, similarity, reason — sorted desc |
| \`find_near_duplicates_in_text(cand, lines[])\` | \`list[dict]\` | same against free-form markdown lines |

A match fires when **either** Jaccard ≥ 0.6 **or** a subset relation holds. Subset is independent because a short rule fully contained in a long one is redundant even when raw Jaccard is dragged down by the long rule's extra tokens.

### \`scripts/propose_claude_md.py\` — wired

For each entry (heuristic, claim, dead end), the proposer now appends a \`⚠ Possibly redundant: <id>\` line when a near-duplicate exists in:

1. Other entries in the same layer (catches cross-session duplicates)
2. Existing \`CLAUDE.md\` / \`AGENTS.md\` at the project root (catches drift between proposals and what the user already has)

The proposer **never** removes, merges, hides, or modifies any entry. The annotation is a suggestion the user reviews.

### Fixture + tests

- \`evals/fixtures/near_duplicate_heuristic.jsonl\` — two sessions, both crystallize \"always use pnpm\" rules. Pipeline produces 2 heuristics; proposer annotates each with the other's id.
- \`tests/test_similarity.py\` — **26 unit tests** (token primitives, Jaccard edge cases, subset semantics, find_near_duplicates contract, find_near_duplicates_in_text against markdown lines).
- \`tests/test_propose_claude_md.py\` — **+3 integration tests**:
  - flags duplicate when fixture produces 2 similar entries
  - does NOT flag when there's only one entry to propose
  - flags against existing \`CLAUDE.md\` at project root

### Doc updates

- \`harness/README.md\` — new section \"Avoiding bloat\" explaining the check
- \`CHANGELOG.md\` — Unreleased section now lists this feature + the #30 fix

## Out of scope (deferred per the suggestion review)

The original *subtractive mode* proposal listed 7 actions and 7 destinations. After analysis, this PR ships the actionable subset and explicitly defers the rest:

| Original suggestion | Ship now? | Why |
|---|---|---|
| Flag near-duplicates within a layer | ✅ | High value, no risk |
| Flag against existing \`CLAUDE.md\` | ✅ | Catches the most realistic case |
| \`merge\` / \`replace\` / \`consider_replacing\` annotations | ✅ | Communicated via \`reason\` field |
| \`remove\` / \`demote\` actions | ❌ | Changes user contract — needs separate discussion |
| Route to wiki / skill / hook / lessons | ❌ | Speculative — those destinations don't exist yet |
| LLM-based semantic similarity | ❌ | Deterministic check covers realistic cases; LLM slots in as additional matcher later |
| \`artifact-commitment\` closure signal | ❌ | Separate issue (#TBD), real git/AST integration |

## Verification

- [x] 155 unit tests pass (was 126, +29)
- [x] 16/16 fixtures pass (was 15, +1), \`false_promotion_rate=0%\`
- [x] 8/8 rule contracts hold
- [x] 8/8 evidence bundles valid (schema + quote traceability)
- [x] Real demo on \`near_duplicate_heuristic.jsonl\`: both H01 and H02 get annotated; count surfaces in stderr summary
- [x] Real demo with a hand-written \`CLAUDE.md\` containing a similar rule: proposal annotated with \`⚠ Already in your CLAUDE.md / AGENTS.md\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)