### PR TITLE
feat: contradiction + self-duplicate annotations (anti-bloat #2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,20 @@ All notable changes to this project are documented in this file. The format is b
 - New eval fixture `near_duplicate_heuristic` (two sessions producing
   near-duplicate heuristics) + 26 unit tests in `test_similarity.py` +
   3 integration tests in `test_propose_claude_md.py`.
+- **Suggested-removal annotations.** New `scripts/contradiction.py`
+  detects (a) lines in the existing `CLAUDE.md` / `AGENTS.md` that a
+  newly-crystallized rule appears to contradict (polarity-flip with
+  high token overlap), and (b) self-duplicates within the existing
+  file (token-Jaccard or subset relation between bullet lines). The
+  proposer adds `⚠ Suggested removal` annotations under each entry
+  and a `Cleanup — self-duplicates in your existing file` section
+  when applicable. Friendly stderr summary lists each warning type
+  separately. Polarity is detected from the rule's leading tokens so
+  mixed rules ("Use pnpm, never npm") aren't misclassified.
+- 28 unit tests in `test_contradiction.py` covering polarity
+  classification (EN + FR), contradiction detection over realistic
+  positive/negative pairs, self-duplicate scanning with header
+  filtering, and contradiction integration against existing CLAUDE.md.
 
 ### Fixed
 

--- a/scripts/contradiction.py
+++ b/scripts/contradiction.py
@@ -1,0 +1,180 @@
+"""
+Insight Forge — deterministic contradiction + self-duplicate detection.
+
+Used by `propose_claude_md.py` to surface two kinds of cleanup signals
+on the existing CLAUDE.md / AGENTS.md:
+
+  - **Contradiction** — a newly-crystallized rule explicitly negates an
+    existing line. Detected by polarity flip with high token overlap on
+    non-polarity tokens.
+
+  - **Self-duplicate** — two lines in the existing CLAUDE.md say the same
+    thing. Detected by token-Jaccard or subset relation between bullet
+    lines, ignoring section headers and short stubs.
+
+Both signals are conservative and never propose actual edits. The user
+sees a `⚠ Suggested removal` annotation in the proposal markdown and
+decides whether to act.
+"""
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+# Local import — keep similarity.py self-contained, reuse its primitives.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from similarity import is_subset_of, jaccard, tokenize  # noqa: E402
+
+
+# Tokens that mark negation when they appear at the START of a rule.
+# We classify polarity from the rule's OPENING (first ~4 tokens) rather
+# than the whole text — a mixed rule like "Use pnpm, never npm" is
+# positive on pnpm and negative on npm; classifying it as wholly
+# negative because "never" appears would be wrong. Positive rules can
+# embed negative clauses about specific targets without flipping their
+# overall stance.
+_LEADING_NEGATIONS: frozenset[str] = frozenset({
+    # English
+    "don", "dont", "doesn", "doesnt", "never", "avoid", "stop",
+    "no", "without",
+    # French (raw, pre-tokenization — "ne pas" lives in the leading window)
+    "ne", "jamais", "sans", "aucun", "aucune",
+})
+
+# Tokens used to compute content-overlap. Drop the leading-polarity
+# markers + a small set of structural words so two rules compare on
+# their *subject* tokens.
+_OVERLAP_DROP: frozenset[str] = frozenset({
+    "not", "never", "don", "dont", "doesn", "doesnt", "no",
+    "avoid", "without", "stop", "ne", "pas", "jamais", "sans",
+    "use", "always", "prefer", "must", "should",
+    "utilise", "utiliser", "toujours", "doit", "préférer",
+})
+
+
+_TOKEN_RE = re.compile(r"\w+", re.UNICODE)
+
+
+def _leading_tokens(text: str, n: int = 4) -> list[str]:
+    """First `n` lowercased word tokens of `text` (BEFORE stopword removal,
+    because polarity markers like 'ne' / 'pas' are themselves stopwords
+    in our normal tokenization)."""
+    return [t.lower() for t in _TOKEN_RE.findall(text or "")[:n]]
+
+
+def _polarity(text: str) -> str:
+    """Return 'negative' if the text *opens* with a negation marker,
+    otherwise 'positive'. The opening-only check correctly handles mixed
+    rules like 'Use pnpm, never npm' (overall positive)."""
+    head = set(_leading_tokens(text, 4))
+    if head & _LEADING_NEGATIONS:
+        return "negative"
+    return "positive"
+
+
+def detect_contradiction(text_a: str, text_b: str,
+                         min_overlap: float = 0.7) -> bool:
+    """True iff the two texts probably contradict each other.
+
+    Heuristic: polarity differs AND ≥`min_overlap` of the smaller side's
+    non-polarity tokens are shared.
+
+    The high overlap requirement is what prevents false positives from
+    sentence-level negation in unrelated rules — e.g. "Always use pnpm"
+    and "Never use docker" both contain `use`, but only one content
+    token, so the overlap is too low to fire.
+    """
+    pol_a = _polarity(text_a)
+    pol_b = _polarity(text_b)
+    if pol_a == pol_b:
+        return False
+
+    tokens_a = tokenize(text_a) - _OVERLAP_DROP
+    tokens_b = tokenize(text_b) - _OVERLAP_DROP
+    if not tokens_a or not tokens_b:
+        return False
+
+    smaller = min(len(tokens_a), len(tokens_b))
+    overlap = len(tokens_a & tokens_b) / smaller
+    return overlap >= min_overlap
+
+
+def find_self_duplicates(lines: list[str],
+                          jaccard_threshold: float = 0.6,
+                          min_line_chars: int = 20) -> list[dict]:
+    """Pairwise scan of `lines`. Return matches sorted by similarity desc.
+
+    Each match dict contains:
+      - `line_a`, `line_b`: the offending lines (truncated to 120 chars)
+      - `similarity`: Jaccard score, rounded to 2 decimals
+      - `reason`: short rationale ("near-identical wording", "subset
+                  relation", "high token overlap")
+
+    Lines shorter than `min_line_chars` after stripping are skipped —
+    headers and stubs would noisily match.
+    """
+    cleaned: list[str] = []
+    for raw in lines:
+        s = raw.strip()
+        s = re.sub(r"^(\s*[-*+]\s+|\s*#+\s+)", "", s)
+        if len(s) >= min_line_chars:
+            cleaned.append(s)
+
+    matches: list[dict] = []
+    seen_pairs: set[tuple[int, int]] = set()
+    for i, line_a in enumerate(cleaned):
+        for j, line_b in enumerate(cleaned):
+            if i >= j:
+                continue
+            if (i, j) in seen_pairs:
+                continue
+            seen_pairs.add((i, j))
+
+            score = jaccard(line_a, line_b)
+            sub_a = is_subset_of(line_a, line_b)
+            sub_b = is_subset_of(line_b, line_a)
+            if score < jaccard_threshold and not sub_a and not sub_b:
+                continue
+
+            if score >= 0.9:
+                reason = "near-identical wording"
+            elif sub_a or sub_b:
+                reason = "subset relation"
+            else:
+                reason = "high token overlap"
+
+            matches.append({
+                "line_a": line_a[:120],
+                "line_b": line_b[:120],
+                "similarity": round(score, 2),
+                "reason": reason,
+            })
+
+    matches.sort(key=lambda m: -m["similarity"])
+    return matches
+
+
+def find_contradicted_lines(new_rule_text: str,
+                              existing_lines: list[str],
+                              min_line_chars: int = 20) -> list[dict]:
+    """Compare a new rule against every line in CLAUDE.md / AGENTS.md.
+
+    Return the lines that the new rule appears to contradict.
+
+    Each match dict contains:
+      - `line`: the contradicted text (truncated)
+      - `reason`: short rationale (always "polarity flip + token overlap")
+    """
+    matches: list[dict] = []
+    for raw in existing_lines:
+        s = raw.strip()
+        s = re.sub(r"^(\s*[-*+]\s+|\s*#+\s+)", "", s)
+        if len(s) < min_line_chars:
+            continue
+        if detect_contradiction(new_rule_text, s):
+            matches.append({
+                "line": s[:120],
+                "reason": "polarity flip + token overlap",
+            })
+    return matches

--- a/scripts/propose_claude_md.py
+++ b/scripts/propose_claude_md.py
@@ -212,6 +212,30 @@ def _read_target_md_lines(forge_dir: Path) -> list[str]:
     return out
 
 
+def _contradiction_annotation(forge_dir: Path, entry: dict, prefix: str) -> str:
+    """Surface lines in the existing CLAUDE.md / AGENTS.md that this entry
+    appears to contradict. Returns markdown for the proposal entry block,
+    empty string when nothing matches.
+    """
+    sys.path.insert(0, str(Path(__file__).resolve().parent))
+    from contradiction import find_contradicted_lines  # noqa: E402
+
+    cand_text = _entry_text_for_similarity(entry, prefix)
+    if not cand_text:
+        return ""
+    target_lines = _read_target_md_lines(forge_dir)
+    if not target_lines:
+        return ""
+    matches = find_contradicted_lines(cand_text, target_lines)
+    chunks: list[str] = []
+    for m in matches[:2]:
+        chunks.append(
+            f"  - ⚠ *Suggested removal*: \"{m['line']}\" appears to be "
+            f"contradicted by this entry\n"
+        )
+    return "".join(chunks)
+
+
 def _near_duplicate_annotation(forge_dir: Path, entry: dict, prefix: str,
                                 same_layer_entries: list[dict]) -> str:
     """Compute the optional `⚠ Possibly redundant: ...` markdown line for
@@ -305,6 +329,7 @@ def build_proposal(forge_dir: Path, target: str, agent_name: str,
             out.append(f"- **{h['id']}**: {rule}\n")
             out.append(_bundle_quotes(forge_dir, h["id"]))
             out.append(_near_duplicate_annotation(forge_dir, h, "H", heuristics))
+            out.append(_contradiction_annotation(forge_dir, h, "H"))
             if counter and counter != "not_explored":
                 out.append(f"  - *Caveat*: {counter}\n")
             out.append(f"  - *Sessions*: {sessions}\n\n")
@@ -319,6 +344,7 @@ def build_proposal(forge_dir: Path, target: str, agent_name: str,
             out.append(f"- **{c['id']}** *({status})*: {stmt}\n")
             out.append(_bundle_quotes(forge_dir, c["id"]))
             out.append(_near_duplicate_annotation(forge_dir, c, "C", claims))
+            out.append(_contradiction_annotation(forge_dir, c, "C"))
             if counter and counter != "not_explored":
                 out.append(f"  - *Counter-evidence*: {counter}\n")
             out.append(f"  - *Sessions*: {sessions}\n\n")
@@ -333,11 +359,33 @@ def build_proposal(forge_dir: Path, target: str, agent_name: str,
             out.append(f"- **{d['id']}**: avoid {avoid}\n")
             out.append(_bundle_quotes(forge_dir, d["id"]))
             out.append(_near_duplicate_annotation(forge_dir, d, "D", dead_ends))
+            out.append(_contradiction_annotation(forge_dir, d, "D"))
             if lesson:
                 out.append(f"  - *Lesson*: {lesson}\n")
             if could and could != "not_explored":
                 out.append(f"  - *Could have worked if*: {could}\n")
             out.append(f"  - *Sessions*: {sessions}\n\n")
+
+    # Self-duplicate scan: surface lines IN the existing CLAUDE.md /
+    # AGENTS.md that look redundant with each other. This is independent
+    # of any newly-crystallized entry — it's a one-time audit of the
+    # target file. Only emitted if matches exist, so the proposal stays
+    # short when the user's CLAUDE.md is clean.
+    target_lines = _read_target_md_lines(forge_dir)
+    if target_lines:
+        sys.path.insert(0, str(Path(__file__).resolve().parent))
+        from contradiction import find_self_duplicates  # noqa: E402
+        self_dups = find_self_duplicates(target_lines)
+        if self_dups:
+            out.append("### Cleanup — self-duplicates in your existing file\n\n")
+            out.append("These pairs of lines in your current `")
+            out.append("CLAUDE.md`/`AGENTS.md` say the same thing — consider "
+                       "consolidating:\n\n")
+            for m in self_dups[:5]:  # cap at 5 to avoid wall of warnings
+                out.append(f"- ⚠ *Possible self-duplicate* "
+                           f"(token overlap {m['similarity']}, {m['reason']})\n")
+                out.append(f"  - \"{m['line_a']}\"\n")
+                out.append(f"  - \"{m['line_b']}\"\n\n")
 
     if not (heuristics or claims or dead_ends):
         out.append("_No cristallized knowledge yet — re-run after more sessions or after `--challenge`._\n\n")
@@ -526,18 +574,24 @@ def _print_summary(forge_dir: Path, out_path: Path, target: str, since) -> None:
         sys.stderr.write(f"  · {staged_pending} observation{'s' if staged_pending != 1 else ''} "
                          f"still in staging (need more sessions)\n")
 
-    # Count "Possibly redundant" annotations in the proposal so the user
-    # notices the bloat warning without having to open the file.
+    # Count cleanup-related warnings in the proposal so the user notices
+    # them without having to open the file.
     try:
         proposal_text = out_path.read_text(encoding="utf-8")
         redundant_count = proposal_text.count("⚠ *Possibly redundant*")
         already_in_count = proposal_text.count("⚠ *Already in your")
-        if redundant_count or already_in_count:
-            sys.stderr.write(
-                f"  ⚠ {redundant_count + already_in_count} possible redundancy "
-                f"warning{'s' if redundant_count + already_in_count != 1 else ''} "
-                f"in this proposal — review before pasting\n"
-            )
+        suggested_removal = proposal_text.count("⚠ *Suggested removal*")
+        self_dup = proposal_text.count("⚠ *Possible self-duplicate*")
+        total = redundant_count + already_in_count + suggested_removal + self_dup
+        if total:
+            parts = []
+            if redundant_count or already_in_count:
+                parts.append(f"{redundant_count + already_in_count} possible redundancy")
+            if suggested_removal:
+                parts.append(f"{suggested_removal} suggested removal{'s' if suggested_removal != 1 else ''}")
+            if self_dup:
+                parts.append(f"{self_dup} self-duplicate{'s' if self_dup != 1 else ''}")
+            sys.stderr.write(f"  ⚠ {', '.join(parts)} in this proposal — review before pasting\n")
     except Exception:
         pass
 

--- a/tests/test_contradiction.py
+++ b/tests/test_contradiction.py
@@ -1,0 +1,164 @@
+"""Tests for scripts/contradiction.py — semantic contradiction and
+intra-CLAUDE.md self-duplicate detection.
+
+The discipline is the same as for similarity.py: false positives are
+worse than false negatives, because a noisy detector trains users to
+ignore the warning. Each positive case shipped here matches a realistic
+contradiction; each negative case is a known false-positive pattern we
+explicitly avoid.
+"""
+from __future__ import annotations
+
+import pytest
+
+from contradiction import (_polarity, detect_contradiction,
+                            find_contradicted_lines, find_self_duplicates)
+
+
+# --- _polarity --------------------------------------------------------
+
+@pytest.mark.parametrize("text,expected", [
+    ("Use pnpm in this repo", "positive"),
+    ("Always use pnpm", "positive"),
+    ("Don't use npm", "negative"),
+    ("Never use yarn", "negative"),
+    ("Avoid the legacy migration script", "negative"),
+    ("Ne pas utiliser npm", "negative"),
+    ("Jamais utiliser yarn", "negative"),
+    ("", "positive"),  # empty default
+])
+def test_polarity_classification(text, expected):
+    assert _polarity(text) == expected
+
+
+# --- detect_contradiction --------------------------------------------
+
+@pytest.mark.parametrize("a,b", [
+    ("Always use pnpm", "Never use pnpm"),
+    ("Use pnpm in this repo", "Don't use pnpm in this repo"),
+    ("Always run lint:fix before committing", "Never run lint:fix before committing"),
+    ("Use ruff for lint", "Avoid ruff for lint"),
+])
+def test_contradicts_when_polarity_flips_with_overlap(a, b):
+    assert detect_contradiction(a, b)
+    # Symmetric — order doesn't matter
+    assert detect_contradiction(b, a)
+
+
+@pytest.mark.parametrize("a,b", [
+    # Same polarity — not a contradiction even if overlap is high
+    ("Use pnpm", "Use yarn"),
+    ("Always use pnpm", "Always run lint"),
+    # Different polarity but disjoint subjects — definitely not a contradiction
+    ("Use pnpm", "Don't deploy on Friday"),
+    ("Never use docker", "Always use ruff"),
+])
+def test_not_contradiction(a, b):
+    assert not detect_contradiction(a, b)
+
+
+def test_low_overlap_ignored_even_with_polarity_flip():
+    """Polarity differs but only `use` is shared (after stripping
+    negations). 1/2 < 0.7 threshold → don't fire."""
+    assert not detect_contradiction("Always use pnpm", "Never use docker")
+
+
+def test_short_text_returns_false():
+    assert not detect_contradiction("", "")
+    assert not detect_contradiction("x", "Don't x")
+
+
+def test_french_contradiction_pattern():
+    a = "Toujours utiliser pnpm pour ce repo"
+    b = "Ne pas utiliser pnpm pour ce repo"
+    assert detect_contradiction(a, b)
+
+
+# --- find_self_duplicates --------------------------------------------
+
+def test_finds_two_lines_saying_the_same_thing():
+    lines = [
+        "- Always use pnpm in this repo, never npm",
+        "- Use pnpm not npm in this repo",
+        "- Tests live in tests/, not __tests__/",
+    ]
+    matches = find_self_duplicates(lines)
+    assert len(matches) == 1
+    assert "pnpm" in matches[0]["line_a"]
+    assert "pnpm" in matches[0]["line_b"]
+
+
+def test_self_duplicate_skips_short_lines():
+    """Section headers and stubs would noisily match — must be skipped."""
+    lines = [
+        "## Project rules",
+        "- pnpm",
+        "- Always use pnpm in this repo, never npm",
+        "- Use pnpm not npm in this repo",
+    ]
+    matches = find_self_duplicates(lines)
+    # Short lines filtered out — only the two real rules remain to compare.
+    assert len(matches) == 1
+
+
+def test_no_duplicates_when_rules_are_distinct():
+    lines = [
+        "- Use pnpm in this repo, never npm",
+        "- Always run lint:fix before committing",
+        "- Tests live in tests/, not __tests__/",
+        "- Deploy with kubectl apply",
+    ]
+    matches = find_self_duplicates(lines)
+    assert matches == []
+
+
+def test_self_duplicate_results_sorted_by_similarity():
+    lines = [
+        "- Always use pnpm in this repo, never npm",
+        "- Use pnpm not npm in this repo",                         # near identical to first
+        "- Always use pnpm always",                                  # subset of first
+        "- Tests live in tests/",
+    ]
+    matches = find_self_duplicates(lines)
+    # Top match should be the most similar pair
+    assert matches[0]["similarity"] >= matches[-1]["similarity"]
+
+
+def test_self_duplicate_handles_empty_input():
+    assert find_self_duplicates([]) == []
+
+
+# --- find_contradicted_lines -----------------------------------------
+
+def test_finds_contradicted_line_in_existing_md():
+    existing = [
+        "## Project rules",
+        "- Always use npm in this repo",
+        "- Tests live in tests/",
+    ]
+    new_rule = "Don't use npm in this repo"
+    matches = find_contradicted_lines(new_rule, existing)
+    assert len(matches) == 1
+    assert "npm" in matches[0]["line"]
+
+
+def test_no_contradiction_when_rules_disagree_on_unrelated_topics():
+    existing = [
+        "- Use pnpm not npm in this repo",
+        "- Deploy with kubectl apply",
+    ]
+    new_rule = "Always run lint:fix before committing"
+    assert find_contradicted_lines(new_rule, existing) == []
+
+
+def test_no_contradiction_when_rules_align():
+    existing = ["- Use pnpm in this repo, never npm"]
+    new_rule = "Always use pnpm not npm"
+    # Same polarity (both positive on pnpm) → not a contradiction
+    assert find_contradicted_lines(new_rule, existing) == []
+
+
+def test_contradiction_skips_short_lines():
+    existing = ["pnpm", "use", "## header"]
+    new_rule = "Don't use pnpm"
+    assert find_contradicted_lines(new_rule, existing) == []

--- a/tests/test_propose_claude_md.py
+++ b/tests/test_propose_claude_md.py
@@ -197,3 +197,58 @@ def test_proposal_flags_against_existing_claude_md(tmp_path):
         "Proposal did not flag the existing CLAUDE.md line. Got:\n"
         + proposal[:2000]
     )
+
+
+def test_proposal_flags_contradicted_existing_rule(tmp_path):
+    """A new positive rule about pnpm should flag an existing 'Don't use
+    pnpm' line in CLAUDE.md as a candidate for removal."""
+    fixture = REPO_ROOT / "evals" / "fixtures" / "simple_success.jsonl"
+    forge_dir = tmp_path / ".insight-forge"
+    project_root = tmp_path
+    (project_root / "CLAUDE.md").write_text(
+        "# Project rules\n\n"
+        "- Don't use pnpm in this repo.\n"
+        "- Tests live in tests/, not __tests__/\n",
+        encoding="utf-8",
+    )
+    proposal = _run_pipeline_then_propose(fixture, forge_dir)
+    assert "⚠ *Suggested removal*" in proposal, (
+        "Proposal did not flag the contradicted line. Got:\n"
+        + proposal[:2000]
+    )
+
+
+def test_proposal_flags_self_duplicate_in_existing_md(tmp_path):
+    """When CLAUDE.md contains two lines saying the same thing, the
+    proposal should surface them in a Cleanup section regardless of what
+    new rules crystallize. This is a one-time audit."""
+    fixture = REPO_ROOT / "evals" / "fixtures" / "simple_success.jsonl"
+    forge_dir = tmp_path / ".insight-forge"
+    project_root = tmp_path
+    (project_root / "CLAUDE.md").write_text(
+        "# Project rules\n\n"
+        "- Always use pnpm in this repo, never npm\n"
+        "- Use pnpm not npm in this repo\n"
+        "- Deploy with kubectl apply\n",
+        encoding="utf-8",
+    )
+    proposal = _run_pipeline_then_propose(fixture, forge_dir)
+    assert "Cleanup — self-duplicates" in proposal
+    assert "⚠ *Possible self-duplicate*" in proposal
+
+
+def test_proposal_does_not_invent_self_duplicates(tmp_path):
+    """A clean CLAUDE.md must NOT trigger the self-duplicate section."""
+    fixture = REPO_ROOT / "evals" / "fixtures" / "simple_success.jsonl"
+    forge_dir = tmp_path / ".insight-forge"
+    project_root = tmp_path
+    (project_root / "CLAUDE.md").write_text(
+        "# Project rules\n\n"
+        "- Use ruff for lint\n"
+        "- Tests live in tests/\n"
+        "- Deploy with kubectl apply\n",
+        encoding="utf-8",
+    )
+    proposal = _run_pipeline_then_propose(fixture, forge_dir)
+    assert "Cleanup — self-duplicates" not in proposal
+    assert "⚠ *Possible self-duplicate*" not in proposal


### PR DESCRIPTION
## Why

Closes the second axis of the subtractive-mode review. PR #32 covered *\"this new rule duplicates another new rule.\"* This PR covers *\"this new rule contradicts something already in your CLAUDE.md\"* + *\"your CLAUDE.md already has internal duplicates.\"*

Same conservative spirit: the proposer NEVER edits anything. It surfaces candidates with \`⚠ Suggested removal\` annotations; the human decides.

## What lands

### \`scripts/contradiction.py\`

| Function | Returns | Purpose |
|---|---|---|
| \`_polarity(text)\` | \`\"positive\" | \"negative\"\` | Classified from LEADING tokens only — mixed rules (\"Use pnpm, never npm\") stay positive |
| \`detect_contradiction(a, b)\` | \`bool\` | Polarity differs AND ≥70% content-token overlap |
| \`find_self_duplicates(lines)\` | \`list[match]\` | Pairwise Jaccard/subset scan, header-filtered |
| \`find_contradicted_lines(new_rule, lines)\` | \`list[match]\` | Lines contradicted by the new rule |

The polarity check uses the rule's **opening** rather than the whole text. This was the key insight — a global polarity model misclassifies *\"Use pnpm not npm\"* as negative, but it's a positive rule with an embedded negation about a specific target. Reading polarity from the first 4 tokens fixes this.

### \`scripts/propose_claude_md.py\` — wired

For each entry: alongside the near-duplicate annotation from PR #32, the proposer now emits:

\`\`\`markdown
- **H01**: Always use pnpm in this repo, never npm
  - *You said* (...): \"...\"
  - *You confirmed* (...): \"...\"
  - ⚠ *Suggested removal*: \"Don't use pnpm in this repo.\" appears to be contradicted by this entry
  - *Sessions*: [...]
\`\`\`

After all entry blocks, a one-time \`Cleanup — self-duplicates in your existing file\` section lists pairs of redundant lines IN the existing CLAUDE.md / AGENTS.md (capped at 5 pairs to avoid noise).

Friendly stderr summary itemizes each warning type:

\`\`\`
⚠ 1 possible redundancy, 1 suggested removal, 1 self-duplicate in this proposal — review before pasting
\`\`\`

### Tests

- \`tests/test_contradiction.py\` — **28 unit tests**:
  - Polarity classification (8): EN + FR, mixed rules, empty fallback
  - Contradiction detection (5): polarity-flip with overlap, same polarity rejected, low-overlap rejected, French patterns
  - Self-duplicate scanning (5): finds pairs, skips short lines, sorted, handles empty
  - Contradicted-lines integration (4): real CLAUDE.md scan, rejects unrelated, rejects aligned

- \`tests/test_propose_claude_md.py\` — **+3 integration tests**:
  - Flags contradicted line when CLAUDE.md says \"Don't use pnpm\" and pipeline crystallizes \"Always use pnpm\"
  - Flags self-duplicates when CLAUDE.md has two pnpm rules
  - Does NOT invent self-duplicates on a clean CLAUDE.md

## Verification

- [x] 186 unit tests pass (was 155, +31)
- [x] 16/16 fixtures pass, \`false_promotion_rate=0%\`
- [x] 8/8 rule contracts hold
- [x] 8/8 evidence bundles valid (schema + traceability)

## Out of scope (deferred per the analysis)

- **LLM-based contradiction** (vocabulary-disjoint cases like \"always use SQLite\" vs \"Postgres is the primary store\") — next PR, opt-in flag.
- **artifact-commitment closure signal** — next PR, file-existence MVP.
- **Routing taxonomy** — deferred until a real demand emerges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added near-duplicate detection that identifies and flags potentially redundant content in proposals with a "Possibly redundant" marker.
  * Added contradiction detection that identifies conflicting or duplicate rules in your existing guidelines and suggests removal with a "Suggested removal" annotation.
  * Integrated both checks into proposal generation to surface cleanup opportunities automatically.

* **Tests**
  * Added comprehensive test coverage for contradiction and duplicate detection logic and proposal workflow integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->