### PR TITLE
feat: artifact-commitment closure signal (MVP, file-existence based)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,25 @@ All notable changes to this project are documented in this file. The format is b
   classification (EN + FR), contradiction detection over realistic
   positive/negative pairs, self-duplicate scanning with header
   filtering, and contradiction integration against existing CLAUDE.md.
+- **artifact-commitment closure signal (MVP)**. Implements signal 4
+  of the ARA closure-signal set, which had been a TODO since the
+  project's first commit. Detection is deterministic and uses two
+  passes: (1) path mentioned in the rule + path exists on disk under
+  the project root; (2) tool name mentioned in the rule + canonical
+  marker file exists OR config file references the tool (e.g.
+  `[tool.ruff]` in `pyproject.toml`, `"packageManager": "pnpm@..."`
+  in `package.json`). No git walk, no AST. Conservative — fires only
+  on hard on-disk evidence.
+- Inserted in `evaluate_maturity` before topic-abandonment (artifact-
+  commitment is stronger evidence than silence over time). When
+  `project_root` is absent (e.g. pipeline run with an unrelated
+  forge_dir), the signal silently skips — preserves backward
+  compatibility.
+- 26 unit tests in `test_artifact_commitment.py` (path extraction,
+  tool extraction, all three matcher branches, defensive paths) +
+  3 integration tests in `test_pipeline_artifact_commitment.py`
+  (signal does not fire without marker, fires when lockfile exists,
+  silent when project_root missing).
 
 ### Fixed
 

--- a/scripts/artifact_commitment.py
+++ b/scripts/artifact_commitment.py
@@ -1,0 +1,164 @@
+"""
+Insight Forge — artifact-commitment closure signal (MVP, no git).
+
+Implements signal 4 of the ARA closure-signal set, which was a TODO in
+pipeline.py until now. The idea: a heuristic about "use X" or "tests live
+in Y/" has earned promotion if the project has actually committed to it
+— i.e. files or config now depend on it.
+
+This MVP uses **path/file existence checks against the project root**.
+No git history walk, no AST parsing, no subprocess calls. Just:
+
+  - Did the user mention a path like `tests/` or `scripts/`? Does it exist?
+  - Did the user mention a well-known tool like `pnpm` or `ruff`? Is the
+    canonical marker file present (`pnpm-lock.yaml`, `[tool.ruff]` in
+    `pyproject.toml`)?
+
+Conservative by design — false positives are worse than false negatives.
+A path mentioned but absent doesn't fire (the rule isn't yet committed
+to the project). A tool mentioned without its canonical marker doesn't
+fire either. The signal is emitted only when there's hard evidence on
+disk.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Optional
+
+
+# Well-known tool → list of file paths that, if present, prove the project
+# is committed to that tool. The lists are intentionally short and only
+# cover canonical markers — fuzzy matches inflate false positives.
+_TOOL_MARKERS: dict[str, list[str]] = {
+    "pnpm": ["pnpm-lock.yaml"],
+    "yarn": ["yarn.lock"],
+    "npm": ["package-lock.json"],
+    "poetry": ["poetry.lock"],
+    "uv": ["uv.lock"],
+    "cargo": ["Cargo.lock"],
+    "ruff": [".ruff.toml", "ruff.toml"],
+    "black": [".black.toml"],
+    "mypy": ["mypy.ini", ".mypy.ini"],
+    "pytest": ["pytest.ini", ".pytest.ini", "conftest.py"],
+    "docker": ["Dockerfile", "docker-compose.yml", "compose.yaml"],
+    "terraform": [".terraform"],
+    "kubectl": ["kustomization.yaml", "kustomization.yml"],
+    "vite": ["vite.config.js", "vite.config.ts"],
+    "webpack": ["webpack.config.js"],
+    "eslint": [".eslintrc", ".eslintrc.js", ".eslintrc.json", ".eslintrc.yaml"],
+    "prettier": [".prettierrc", ".prettierrc.json", ".prettierrc.js"],
+}
+
+# Tools whose presence is signalled by a config file mentioning them
+# (e.g. `[tool.ruff]` in pyproject.toml). Each entry is
+# (tool_name, [(filename, regex_pattern), ...]).
+_CONFIG_REFERENCES: dict[str, list[tuple[str, str]]] = {
+    "ruff": [("pyproject.toml", r"\[tool\.ruff")],
+    "black": [("pyproject.toml", r"\[tool\.black")],
+    "mypy": [("pyproject.toml", r"\[tool\.mypy")],
+    "pytest": [("pyproject.toml", r"\[tool\.pytest")],
+    "pnpm": [("package.json", r'"packageManager"\s*:\s*"pnpm')],
+    "yarn": [("package.json", r'"packageManager"\s*:\s*"yarn')],
+}
+
+# Path-shaped tokens to detect in observation text. Accepts:
+#   - directory paths with trailing slash:   tests/, src/components/
+#   - nested file paths:                      src/components/Header.tsx
+#   - leading-dot paths:                      .github/workflows/main.yml
+#   - bare filenames with known extensions:   pyproject.toml, package.json
+_PATH_RE = re.compile(
+    r"(?<![\w/])"                                 # boundary (no word/slash before)
+    r"("
+    r"\.?[A-Za-z][\w\-]*"                          # first segment, optional leading dot
+    r"(?:/[\w\-]+)*"                               # zero or more middle dir segments
+    r"(?:/|\.[A-Za-z][\w]{0,5})"                    # trailing slash OR file extension
+    r")"
+    r"(?![\w/])"                                   # boundary after
+)
+
+
+def _extract_paths(text: str) -> list[str]:
+    """Pull path-shaped tokens out of the rule text."""
+    if not text:
+        return []
+    out: list[str] = []
+    for m in _PATH_RE.finditer(text):
+        path = m.group(1)
+        if not path:
+            continue
+        clean = path.rstrip("/")
+        if clean and clean not in out:
+            out.append(clean)
+    return out
+
+
+def _extract_tools(text: str) -> list[str]:
+    """Pull well-known tool names out of the rule text (case-insensitive)."""
+    if not text:
+        return []
+    text_lower = text.lower()
+    out: list[str] = []
+    for tool in _TOOL_MARKERS:
+        # Word-boundary match so `pnpm` doesn't match `pnpmpkg` or similar.
+        if re.search(rf"\b{re.escape(tool)}\b", text_lower):
+            out.append(tool)
+    return out
+
+
+def detect_artifact_commitment(observation_text: str,
+                                  project_root: Optional[Path]) -> Optional[str]:
+    """Return a human-readable description of the matched artifact, or None.
+
+    Two passes:
+      1. Path mentioned in the rule + file/dir exists at project_root
+      2. Tool mentioned in the rule + canonical marker file exists OR
+         config file references the tool
+
+    Returns the FIRST hit. Conservative — null when there's no evidence,
+    null when project_root is missing/None, null on any I/O error.
+    """
+    if not observation_text or project_root is None:
+        return None
+    try:
+        if not project_root.exists() or not project_root.is_dir():
+            return None
+    except OSError:
+        return None
+
+    # --- Pass 1: path-based ---------------------------------------------
+    for path_str in _extract_paths(observation_text):
+        # Skip path tokens that are mostly noise (e.g. things like "I/O"
+        # would be filtered by the regex but be defensive).
+        if len(path_str) < 2:
+            continue
+        candidate = project_root / path_str
+        try:
+            if candidate.exists():
+                return f"path '{path_str}' exists in project"
+        except OSError:
+            continue
+
+    # --- Pass 2: tool-based ---------------------------------------------
+    for tool in _extract_tools(observation_text):
+        # 2a. Marker files
+        for marker in _TOOL_MARKERS.get(tool, []):
+            try:
+                if (project_root / marker).exists():
+                    return f"tool '{tool}' confirmed by '{marker}'"
+            except OSError:
+                continue
+
+        # 2b. Config-file references (e.g. [tool.ruff] in pyproject.toml)
+        for config_file, pattern in _CONFIG_REFERENCES.get(tool, []):
+            cf = project_root / config_file
+            try:
+                if not cf.exists():
+                    continue
+                content = cf.read_text(encoding="utf-8")
+            except (OSError, UnicodeDecodeError):
+                continue
+            if re.search(pattern, content):
+                return f"tool '{tool}' referenced in '{config_file}'"
+
+    return None

--- a/scripts/pipeline.py
+++ b/scripts/pipeline.py
@@ -808,8 +808,15 @@ def generate_counter_evidence(observation: dict, type_: str) -> str:
 
 
 def evaluate_maturity(obs: dict, all_candidates: list[CandidateEvent],
-                       all_sessions: list[dict]) -> CrystallizationDecision:
-    """Apply the 4 closure signals."""
+                       all_sessions: list[dict],
+                       project_root: Optional[Path] = None) -> CrystallizationDecision:
+    """Apply the 4 closure signals.
+
+    `project_root` is the directory used to scan for artifact-commitment
+    evidence (file existence, config references). When None, that signal
+    silently skips — preserves backward compatibility with callers that
+    don't have a project root context.
+    """
     obs_id = obs.get("id", "?")
     pot_type = obs.get("potential_type", "unknown")
 
@@ -856,6 +863,24 @@ def evaluate_maturity(obs: dict, all_candidates: list[CandidateEvent],
             generate_counter_evidence({"content": obs.get("content", "")}, "dead_end"),
         )
 
+    # Signal 4: artifact commitment — code or config now depends on this
+    # observation. Stronger evidence than topic-abandonment (which is just
+    # silence over time), so it fires BEFORE the abandonment check.
+    if project_root is not None:
+        try:
+            sys.path.insert(0, str(Path(__file__).resolve().parent))
+            from artifact_commitment import detect_artifact_commitment  # noqa: E402
+            artifact = detect_artifact_commitment(obs.get("content", ""), project_root)
+            if artifact:
+                return CrystallizationDecision(
+                    obs_id, "artifact-commitment", target,
+                    f"Artifact found: {artifact}",
+                    generate_counter_evidence(obs, target),
+                )
+        except Exception:
+            # Defensive: artifact detection must never break the pipeline.
+            pass
+
     # Signal 1: topic abandonment
     if detect_topic_abandonment(obs, all_sessions):
         return CrystallizationDecision(
@@ -863,9 +888,6 @@ def evaluate_maturity(obs: dict, all_candidates: list[CandidateEvent],
             "Topic absent from recent sessions",
             generate_counter_evidence(obs, target),
         )
-
-    # Signal 4: artifact commitment
-    # (Hard to check without actual git/file scanning — left as TODO)
 
     # No signal fired
     return CrystallizationDecision(obs_id, None, None, "no signal fired", "")
@@ -1196,13 +1218,21 @@ def run_pipeline(input_path: Path, forge_dir: Path,
     crystallized_count = 0
     contradictions = 0
 
+    # Project root for artifact-commitment scanning. By convention forge_dir
+    # is `.insight-forge/` inside the project root, so the parent is what
+    # we scan. When pipeline.py is invoked with an explicit forge_dir
+    # somewhere unrelated, the parent may not be a real project — in that
+    # case detect_artifact_commitment returns None silently.
+    project_root = forge_dir.parent
+
     for obs in obs_data.get("observations", []):
         if obs.get("promoted"):
             continue
         # Build a session_index-like list for topic-abandonment check
         all_session_summaries = [{"id": m.get("session_short", ""), "date": m.get("mtime", ""),
                                   "summary": ""} for m in session_metas]
-        decision = evaluate_maturity(obs, candidates, all_session_summaries)
+        decision = evaluate_maturity(obs, candidates, all_session_summaries,
+                                       project_root=project_root)
 
         if decision.fired_signal is None:
             # Stale check

--- a/tests/test_artifact_commitment.py
+++ b/tests/test_artifact_commitment.py
@@ -1,0 +1,184 @@
+"""Tests for scripts/artifact_commitment.py — file-existence MVP for the
+artifact-commitment closure signal.
+
+Conservative discipline: false positives are worse than false negatives.
+A path mentioned but absent shouldn't fire (the rule isn't yet committed
+to the project). A tool name without its canonical marker shouldn't fire
+either. The signal is only emitted when there's hard evidence on disk.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from artifact_commitment import (_extract_paths, _extract_tools,
+                                    detect_artifact_commitment)
+
+
+# --- _extract_paths ---------------------------------------------------
+
+@pytest.mark.parametrize("text,expected_subset", [
+    ("Tests live in tests/, not __tests__/", {"tests"}),
+    ("Use src/components/Header.tsx for the layout", {"src/components/Header.tsx"}),
+    ("CI config is at .github/workflows/main.yml", {".github/workflows/main.yml"}),
+    ("The pyproject.toml has the config", {"pyproject.toml"}),
+    # Plain English — no path mentions
+    ("Use pnpm for package management", set()),
+])
+def test_extract_paths_finds_real_paths(text, expected_subset):
+    paths = set(_extract_paths(text))
+    for p in expected_subset:
+        assert p in paths, f"expected {p!r} in {paths!r}"
+
+
+def test_extract_paths_handles_empty():
+    assert _extract_paths("") == []
+    assert _extract_paths(None) == []
+
+
+# --- _extract_tools ---------------------------------------------------
+
+@pytest.mark.parametrize("text,expected", [
+    ("Use pnpm not npm", {"pnpm", "npm"}),
+    ("Always run ruff for lint", {"ruff"}),
+    ("Use mypy for type checks", {"mypy"}),
+    ("Deploy with kubectl apply", {"kubectl"}),
+    # Tool name embedded in another word — must NOT match
+    ("This pnpmpkg is unrelated", set()),
+])
+def test_extract_tools_finds_known_tools(text, expected):
+    tools = set(_extract_tools(text))
+    if expected:
+        assert tools >= expected, f"expected {expected} in {tools}"
+    else:
+        assert tools == set()
+
+
+def test_extract_tools_case_insensitive():
+    """Tool names should match regardless of case."""
+    assert "ruff" in _extract_tools("Always run RUFF for lint")
+    assert "pnpm" in _extract_tools("Use PnPm here")
+
+
+# --- detect_artifact_commitment: path-based --------------------------
+
+def test_path_match_when_directory_exists(tmp_path):
+    (tmp_path / "tests").mkdir()
+    result = detect_artifact_commitment(
+        "Tests live in tests/, not __tests__/", tmp_path,
+    )
+    assert result is not None
+    assert "tests" in result
+
+
+def test_path_no_match_when_directory_absent(tmp_path):
+    """Mentioned path doesn't exist on disk → no commitment."""
+    result = detect_artifact_commitment(
+        "Tests live in tests/, not __tests__/", tmp_path,
+    )
+    assert result is None
+
+
+def test_path_match_with_filename(tmp_path):
+    (tmp_path / "pyproject.toml").write_text("[project]\nname='x'\n")
+    result = detect_artifact_commitment(
+        "Configuration lives in pyproject.toml", tmp_path,
+    )
+    assert result is not None
+
+
+# --- detect_artifact_commitment: tool-marker --------------------------
+
+def test_tool_marker_pnpm_lock_present(tmp_path):
+    (tmp_path / "pnpm-lock.yaml").write_text("lockfileVersion: '6.0'\n")
+    result = detect_artifact_commitment(
+        "Use pnpm for package management", tmp_path,
+    )
+    assert result is not None
+    assert "pnpm" in result and "pnpm-lock.yaml" in result
+
+
+def test_tool_marker_yarn_lock_present(tmp_path):
+    (tmp_path / "yarn.lock").write_text("# yarn lockfile v1\n")
+    result = detect_artifact_commitment(
+        "Use yarn for this monorepo", tmp_path,
+    )
+    assert result is not None
+    assert "yarn" in result
+
+
+def test_tool_no_match_without_marker(tmp_path):
+    """Mentioned tool without its lockfile/config → no commitment."""
+    result = detect_artifact_commitment("Use pnpm here", tmp_path)
+    assert result is None
+
+
+# --- detect_artifact_commitment: config-reference --------------------
+
+def test_ruff_config_in_pyproject(tmp_path):
+    (tmp_path / "pyproject.toml").write_text(
+        "[project]\nname='x'\n\n[tool.ruff]\nline-length = 100\n"
+    )
+    result = detect_artifact_commitment("Always use ruff for lint", tmp_path)
+    assert result is not None
+    assert "ruff" in result
+    assert "pyproject.toml" in result
+
+
+def test_pnpm_packagemanager_in_package_json(tmp_path):
+    (tmp_path / "package.json").write_text(
+        '{"name": "x", "packageManager": "pnpm@9.0.0"}'
+    )
+    result = detect_artifact_commitment("Use pnpm in this repo", tmp_path)
+    assert result is not None
+    assert "pnpm" in result
+
+
+def test_no_config_reference_when_pyproject_absent(tmp_path):
+    """Tool mentioned, pyproject.toml present but does NOT mention the
+    tool → no commitment."""
+    (tmp_path / "pyproject.toml").write_text("[project]\nname='x'\n")
+    result = detect_artifact_commitment("Use ruff for lint", tmp_path)
+    assert result is None
+
+
+# --- defensive paths --------------------------------------------------
+
+def test_returns_none_when_project_root_is_none():
+    assert detect_artifact_commitment("Use pnpm", None) is None
+
+
+def test_returns_none_when_project_root_does_not_exist(tmp_path):
+    fake = tmp_path / "does-not-exist"
+    assert detect_artifact_commitment("Use pnpm", fake) is None
+
+
+def test_returns_none_when_observation_text_is_empty(tmp_path):
+    (tmp_path / "pnpm-lock.yaml").write_text("x")
+    assert detect_artifact_commitment("", tmp_path) is None
+    assert detect_artifact_commitment(None, tmp_path) is None
+
+
+def test_handles_unreadable_config_silently(tmp_path):
+    """If pyproject.toml exists but can't be read (permission, encoding),
+    we should NOT crash — we should silently fall through to other
+    matchers."""
+    cf = tmp_path / "pyproject.toml"
+    cf.write_bytes(b"\xff\xfe\x00\x00invalid")  # invalid UTF-8
+    # No marker file, no readable config → None
+    result = detect_artifact_commitment("Use ruff", tmp_path)
+    assert result is None
+
+
+def test_first_match_wins(tmp_path):
+    """When both a path AND a tool marker would fire, the path is checked
+    first (more specific to the rule's intent)."""
+    (tmp_path / "tests").mkdir()
+    (tmp_path / "pnpm-lock.yaml").write_text("x")
+    result = detect_artifact_commitment(
+        "Tests live in tests/ and we use pnpm", tmp_path,
+    )
+    assert result is not None
+    # Either path or tool match is acceptable; just verify it fires.
+    assert "tests" in result or "pnpm" in result

--- a/tests/test_pipeline_artifact_commitment.py
+++ b/tests/test_pipeline_artifact_commitment.py
@@ -1,0 +1,103 @@
+"""Integration test: artifact-commitment closure signal fires through the
+full pipeline when a project root has on-disk evidence for a staged
+observation.
+
+The fixture used here is a bare assistant claim about pnpm — no verbal
+affirmation in the same session, no tool result, only one session so
+no topic-abandonment is possible. Without artifact-commitment, the
+observation would stay in staging. With a `pnpm-lock.yaml` present in
+the project root, it should crystallize via artifact-commitment.
+"""
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def _write_fixture(path: Path) -> None:
+    """A minimal session that stages a claim about pnpm without any
+    closure signal. Without artifact-commitment, this stays in staging."""
+    path.write_text(textwrap.dedent("""\
+        {"_marker": "session_start", "session_id": "art00001-0000-0000-0000-000000000001", "session_short": "art00001", "agent": "claude", "mtime": "2026-05-04T10:00:00", "size_kb": 2}
+        {"role": "assistant", "content": "pnpm is faster than npm because of its content-addressable store, when caching is hot.", "timestamp": "2026-05-04T10:00:05", "session_id": "art00001-0000-0000-0000-000000000001", "session_short": "art00001", "agent": "claude"}
+        {"role": "user", "content": "ok cool, let's continue with the deploy", "timestamp": "2026-05-04T10:00:10", "session_id": "art00001-0000-0000-0000-000000000001", "session_short": "art00001", "agent": "claude"}
+        {"_marker": "session_end"}
+    """), encoding="utf-8")
+
+
+def _run_pipeline(fixture: Path, forge_dir: Path) -> dict:
+    """Run pipeline.py and return the parsed JSON summary."""
+    res = subprocess.run(
+        [sys.executable, str(REPO_ROOT / "scripts" / "pipeline.py"),
+          "--input", str(fixture), "--forge-dir", str(forge_dir)],
+        capture_output=True, text=True,
+    )
+    assert res.returncode == 0, f"pipeline failed: {res.stderr}"
+    # pipeline.py writes status to stderr and the JSON summary to stdout
+    return json.loads(res.stdout)
+
+
+def test_artifact_commitment_does_not_fire_without_marker(tmp_path):
+    """Same fixture, NO pnpm-lock.yaml in project root → no crystallization
+    via artifact-commitment. Observation stays in staging."""
+    fixture = tmp_path / "f.jsonl"
+    _write_fixture(fixture)
+    project_root = tmp_path
+    forge_dir = project_root / ".insight-forge"
+
+    summary = _run_pipeline(fixture, forge_dir)
+
+    # No closure signal fires → 0 crystallized, 1 staged.
+    assert summary["crystallized"] == 0
+    assert summary["staged"] >= 1
+
+
+def test_artifact_commitment_fires_when_lockfile_exists(tmp_path):
+    """Same fixture, but pnpm-lock.yaml present in project root → the
+    staged claim about pnpm crystallizes via artifact-commitment."""
+    fixture = tmp_path / "f.jsonl"
+    _write_fixture(fixture)
+    project_root = tmp_path
+    forge_dir = project_root / ".insight-forge"
+
+    # Plant the artifact BEFORE running the pipeline.
+    (project_root / "pnpm-lock.yaml").write_text("lockfileVersion: '6.0'\n")
+
+    summary = _run_pipeline(fixture, forge_dir)
+
+    assert summary["crystallized"] >= 1, (
+        "Expected at least one crystallization via artifact-commitment.\n"
+        f"Got summary: {summary}"
+    )
+
+    # Verify the bundle records the right closure signal.
+    bundles_dir = forge_dir / "evidence" / "bundles"
+    bundle_files = [b for b in bundles_dir.glob("*.yaml") if b.name != "README.md"]
+    assert bundle_files, "no evidence bundle written"
+
+    text = bundle_files[0].read_text(encoding="utf-8")
+    assert "crystallized_via" in text
+    assert "artifact-commitment" in text
+
+
+def test_artifact_commitment_silent_when_project_root_missing(tmp_path):
+    """When pipeline.py runs with a forge_dir whose parent doesn't contain
+    a real project, artifact-commitment must not crash and must simply
+    return None — preserving the existing observation flow."""
+    fixture = tmp_path / "f.jsonl"
+    _write_fixture(fixture)
+    # Use a forge_dir whose parent is a fresh empty tmp dir
+    forge_dir = tmp_path / "deeply" / "nested" / ".insight-forge"
+
+    summary = _run_pipeline(fixture, forge_dir)
+
+    # No crash, no crystallization, observation stays staged.
+    assert summary["crystallized"] == 0


### PR DESCRIPTION
## Why

Closes the 4th ARA closure signal that had been a TODO in \`pipeline.py\` since the project's first commit. The README always promised four signals — \`verbal-affirmation\`, \`empirical-resolution\`, \`topic-abandonment\`, \`artifact-commitment\` — but only three were implemented. This PR fills the gap with a **deterministic, file-existence-based MVP**. No git walk, no AST parsing, no subprocess calls.

## Detection logic

Two passes, first hit wins:

| Pass | Trigger |
|---|---|
| **Path** | Rule mentions a path (\`tests/\`, \`src/components/Header.tsx\`, \`.github/workflows/main.yml\`) + path exists under project root |
| **Tool** | Rule mentions a known tool (\`pnpm\`, \`ruff\`, \`yarn\`, \`mypy\`, \`docker\`...) + canonical marker file present OR config references it |

Marker examples:
- \`pnpm\` → \`pnpm-lock.yaml\`
- \`ruff\` → \`.ruff.toml\` OR \`[tool.ruff]\` in \`pyproject.toml\`
- \`pnpm\` (alt) → \`\"packageManager\": \"pnpm@...\"\` in \`package.json\`

Conservative throughout: false positives are worse than false negatives. A tool name without its marker file does NOT fire. Word-boundary regex on tool names (\`pnpm\` doesn't match \`pnpmpkg\`). Silent \`None\` on missing project_root, unreadable config, OSError, missing observation text.

## Pipeline integration

\`evaluate_maturity()\` now takes an optional \`project_root\` argument and checks artifact-commitment **between empirical-resolution and topic-abandonment**. Order matters — artifact-commitment is stronger evidence than \"silence over time\", so it should fire first when both could.

\`run_pipeline()\` passes \`forge_dir.parent\` as project_root by convention (insight-forge always writes to \`<project>/.insight-forge/\`). When that parent isn't a real project (e.g. eval harness uses \`/tmp\`), detection silently returns \`None\` — preserving backward compatibility for every existing fixture.

## Tests

- **\`tests/test_artifact_commitment.py\`** — 26 unit tests:
  - 4 path extraction (incl. nested files, leading-dot paths, bare filenames)
  - 4 tool extraction (case-insensitive, word-boundary, no embedded matches)
  - 3 path-based match (directory, absent, file)
  - 3 tool-marker match (pnpm-lock, yarn.lock, no match without marker)
  - 3 config-reference match (\`[tool.ruff]\`, \`packageManager\`, no match when key absent)
  - 5 defensive paths (None project, missing dir, empty text, unreadable config, first-match-wins)

- **\`tests/test_pipeline_artifact_commitment.py\`** — 3 integration tests:
  - fixture stages a pnpm claim with no closure signal; without \`pnpm-lock.yaml\` → stays staged (0 promoted)
  - same fixture with \`pnpm-lock.yaml\` planted → crystallizes via artifact-commitment; bundle records the right \`crystallized_via\`
  - forge_dir whose parent doesn't exist → no crash, observation stays staged

## Verification

- [x] 215 unit tests pass (was 186, +29)
- [x] 16/16 fixtures pass, \`false_promotion_rate=0%\`
- [x] 8/8 rule contracts hold
- [x] 8/8 evidence bundles valid (schema + quote traceability)
- [x] Existing fixtures' behavior unchanged — they crystallize via the same signals as before because the eval harness uses \`/tmp\` as forge_dir parent (no project artifacts)

## Out of scope (future)

- Git history scanning (\"a commit references this rule's keyword\")
- AST parsing of source files for deeper artifact relations
- Detection of REMOVAL of artifacts (could fire as counter-evidence)
- LLM-augmented artifact reasoning

🤖 Generated with [Claude Code](https://claude.com/claude-code)