### PR TITLE
feat: opt-in semantic similarity seam in find_near_duplicates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,15 @@ All notable changes to this project are documented in this file. The format is b
   3 integration tests in `test_pipeline_artifact_commitment.py`
   (signal does not fire without marker, fires when lockfile exists,
   silent when project_root missing).
+- **Opt-in semantic similarity seam.** `find_near_duplicates` now
+  accepts an `extra_matcher` callable that's invoked only when the
+  deterministic check finds nothing — keeps token cost at zero on
+  the common path. The callable receives `(candidate, existing)` and
+  returns extra `{id, similarity, reason}` matches. Designed for
+  LLM / embedding providers without coupling the repo to any specific
+  SDK. Defensive: errors from a misbehaving provider surface on
+  stderr and never crash the proposer; malformed return values are
+  filtered. 6 unit tests pin the contract.
 
 ### Fixed
 

--- a/harness/README.md
+++ b/harness/README.md
@@ -199,6 +199,46 @@ is a suggestion the user reviews; the human decides whether to merge,
 replace, keep both, or do something else entirely. Same conservative
 contract as the rest of the project.
 
+### Opt-in semantic similarity (LLM / embedding seam)
+
+The deterministic Jaccard check catches most realistic duplicates but
+misses **vocabulary-disjoint** cases — e.g. *"always use SQLite"* vs
+*"Postgres is the primary store"* share zero tokens after stopword
+removal but contradict each other.
+
+`find_near_duplicates(..., extra_matcher=callable)` accepts a user-
+provided callable that's invoked **only when the deterministic check
+finds nothing**. This keeps token cost at zero on the common path. The
+callable receives `(candidate_text, existing_entries)` and returns a
+list of `{id, similarity, reason}` dicts.
+
+```python
+from similarity import find_near_duplicates
+
+def my_llm_matcher(candidate, existing):
+    # Call your LLM provider, return matches the cheap check missed.
+    # The repo intentionally doesn't ship a specific SDK adapter —
+    # provider choice, cost limits, and prompt design belong to the user.
+    ...
+
+result = find_near_duplicates(
+    candidate_text=text,
+    candidate_id="C99",
+    candidate_session="...",
+    existing_entries=entries,
+    extra_matcher=my_llm_matcher,    # opt-in, costs tokens
+)
+```
+
+The seam is defensive: a matcher that raises does not crash the
+proposer, just surfaces a single stderr line and falls back to the
+deterministic result. A matcher returning malformed entries (non-dict,
+missing `id`) silently drops them.
+
+To wire an LLM provider system-wide, pass `extra_matcher=` from your
+own script that imports `propose_claude_md`. The default proposer
+flow does not invoke an LLM unless you opt in.
+
 ## Marking a known gap
 
 Add to `evals/expected/<fixture>.expected.yaml`:

--- a/scripts/similarity.py
+++ b/scripts/similarity.py
@@ -80,12 +80,40 @@ def is_subset_of(short: str, long: str, threshold: float = 0.85) -> bool:
     return len(a & b) / len(a) >= threshold
 
 
+SimilarityMatcher = "Callable[[str, list[dict]], list[dict]]"
+"""Type alias for an extra matcher plugged into find_near_duplicates.
+
+The matcher receives:
+  - candidate_text: the new entry being checked
+  - existing_entries: list of {id, text, ...} dicts
+
+It returns a list of extra match dicts {id, similarity, reason} that the
+caller will merge with deterministic results (deduplicated by id, the
+first reason wins). Designed for opt-in semantic-similarity providers
+(LLM, embedding service, etc.) without coupling the repo to any specific
+SDK — the user supplies the callable.
+
+Example wiring (pseudo-code):
+
+    def my_llm_matcher(candidate, existing):
+        # call your favourite LLM API, return [{id, similarity, reason}, ...]
+        ...
+
+    matches = find_near_duplicates(
+        candidate_text=text,
+        ...,
+        extra_matcher=my_llm_matcher,
+    )
+"""
+
+
 def find_near_duplicates(
     candidate_text: str,
     candidate_id: str,
     candidate_session: str,
     existing_entries: list[dict],
     threshold: float = 0.6,
+    extra_matcher=None,
 ) -> list[dict]:
     """Compare candidate against every existing entry. Return matches.
 
@@ -138,6 +166,34 @@ def find_near_duplicates(
             "similarity": round(score, 2),
             "reason": "; ".join(reasons),
         })
+
+    # Optional extra matcher (LLM-based, embedding-based, ...). Called only
+    # when deterministic finds nothing — keeps token costs at zero on the
+    # common path. Errors from the user-supplied matcher are caught so a
+    # broken provider can never crash the proposer.
+    if extra_matcher is not None and not matches:
+        try:
+            extras = extra_matcher(candidate_text, existing_entries) or []
+            seen_ids = set()  # always empty here since `matches` is empty
+            for ex in extras:
+                if not isinstance(ex, dict):
+                    continue
+                ex_id = ex.get("id")
+                if not ex_id or ex_id == candidate_id or ex_id in seen_ids:
+                    continue
+                seen_ids.add(ex_id)
+                matches.append({
+                    "id": ex_id,
+                    "similarity": round(float(ex.get("similarity", 0.5)), 2),
+                    "reason": ex.get("reason", "extra matcher"),
+                })
+        except Exception as exc:
+            # Defensive: a misbehaving matcher must never break the
+            # proposal. Surface a single line to stderr so users notice.
+            import sys
+            print(f"[insight-forge] extra_matcher raised {type(exc).__name__}: "
+                  f"{exc} — falling back to deterministic only",
+                  file=sys.stderr)
 
     matches.sort(key=lambda m: -m["similarity"])
     return matches

--- a/tests/test_similarity.py
+++ b/tests/test_similarity.py
@@ -262,3 +262,133 @@ def test_text_lines_returns_only_best_match():
         text_lines=lines,
     )
     assert len(result) == 1
+
+
+# --- extra_matcher seam (opt-in semantic similarity) ------------------
+
+def test_extra_matcher_called_when_deterministic_finds_nothing():
+    """The seam: when deterministic returns no matches, an extra matcher
+    can supply additional results. This is the entry point for an opt-in
+    LLM/embedding provider."""
+    existing = [
+        {"id": "C01", "text": "Postgres is the primary store",
+          "session": "aaaa1111"},
+    ]
+
+    def fake_llm_matcher(candidate, existing_entries):
+        # Pretend the LLM detected a semantic contradiction.
+        return [{
+            "id": "C01",
+            "similarity": 0.85,
+            "reason": "llm: same architectural choice topic, opposite",
+        }]
+
+    result = find_near_duplicates(
+        candidate_text="Always use SQLite for the data store",
+        candidate_id="C99",
+        candidate_session="bbbb2222",
+        existing_entries=existing,
+        extra_matcher=fake_llm_matcher,
+    )
+    assert len(result) == 1
+    assert result[0]["id"] == "C01"
+    assert "llm" in result[0]["reason"]
+
+
+def test_extra_matcher_skipped_when_deterministic_finds_match():
+    """Cost discipline: if the cheap deterministic check already found a
+    match, the extra matcher is NOT called. Keeps token usage at zero
+    on the common path."""
+    existing = [
+        {"id": "H01", "text": "Use pnpm not npm in this repo",
+          "session": "aaaa1111"},
+    ]
+    call_count = [0]
+
+    def fake_matcher(candidate, existing_entries):
+        call_count[0] += 1
+        return []
+
+    find_near_duplicates(
+        candidate_text="Always use pnpm in this repo, never npm",
+        candidate_id="H02",
+        candidate_session="bbbb2222",
+        existing_entries=existing,
+        extra_matcher=fake_matcher,
+    )
+    assert call_count[0] == 0, \
+        "extra_matcher was invoked despite deterministic match"
+
+
+def test_extra_matcher_errors_are_caught(capsys):
+    """A broken matcher must NEVER crash the proposer. The error surfaces
+    on stderr so the user knows, but the deterministic result wins."""
+    def broken_matcher(candidate, existing):
+        raise RuntimeError("my LLM provider is on fire")
+
+    result = find_near_duplicates(
+        candidate_text="Always use SQLite",
+        candidate_id="C99",
+        candidate_session="z",
+        existing_entries=[{"id": "C01", "text": "totally unrelated rule",
+                            "session": "x"}],
+        extra_matcher=broken_matcher,
+    )
+    # No deterministic match, broken extra matcher → empty result, no crash
+    assert result == []
+    captured = capsys.readouterr()
+    assert "extra_matcher raised" in captured.err
+
+
+def test_extra_matcher_skips_self_id_in_extras():
+    """If the extra matcher mistakenly returns the candidate's own id,
+    it must be filtered out — same self-comparison guard as the
+    deterministic path."""
+    def fake(candidate, existing):
+        return [{"id": "C99", "similarity": 0.8, "reason": "fake"},
+                {"id": "C01", "similarity": 0.7, "reason": "real"}]
+
+    result = find_near_duplicates(
+        candidate_text="anything",
+        candidate_id="C99",
+        candidate_session="z",
+        existing_entries=[{"id": "C01", "text": "totally unrelated"}],
+        extra_matcher=fake,
+    )
+    assert len(result) == 1
+    assert result[0]["id"] == "C01"
+
+
+def test_extra_matcher_handles_malformed_returns():
+    """Defensive: a matcher that returns non-dict items, or items missing
+    `id`, must be filtered without crashing."""
+    def malformed(candidate, existing):
+        return [
+            None,                                        # not a dict
+            {"similarity": 0.9, "reason": "no id"},       # missing id
+            {"id": "C01", "similarity": 0.7, "reason": "ok"},
+        ]
+
+    result = find_near_duplicates(
+        candidate_text="x",
+        candidate_id="C99",
+        candidate_session="z",
+        existing_entries=[{"id": "C01", "text": "totally unrelated"}],
+        extra_matcher=malformed,
+    )
+    assert len(result) == 1
+    assert result[0]["id"] == "C01"
+
+
+def test_extra_matcher_returning_none_is_treated_as_empty():
+    def returns_none(candidate, existing):
+        return None
+
+    result = find_near_duplicates(
+        candidate_text="x",
+        candidate_id="C99",
+        candidate_session="z",
+        existing_entries=[{"id": "C01", "text": "totally unrelated"}],
+        extra_matcher=returns_none,
+    )
+    assert result == []


### PR DESCRIPTION
## Why

Closes the third deferred item from the subtractive-mode review **without coupling the repo to any specific LLM SDK**. The deterministic Jaccard check covers most realistic duplicates but misses vocabulary-disjoint cases — e.g. *\"always use SQLite\"* vs *\"Postgres is the primary store\"* share zero tokens after stopword removal but contradict each other. This PR adds a callable hook that user code can wire to an LLM, embedding service, or any other matcher.

## Design

\`find_near_duplicates(..., extra_matcher: Callable | None = None)\`

- **Signature**: \`(candidate_text, existing_entries) → list[{id, similarity, reason}]\`
- **Invoked only when deterministic finds zero matches** — keeps token cost at zero on the common path. This is the cost-discipline contract.
- **Results are filtered** (skip self_id, skip non-dict items, skip items missing \`id\`) and merged into the result list.
- **Errors are caught**: a broken matcher surfaces a single stderr line and the proposer falls back to deterministic-only. A misbehaving provider must NEVER crash the proposer.

The repo intentionally does **not** ship a specific provider adapter (Anthropic SDK, OpenAI SDK, etc.). Provider choice, cost limits, and prompt design belong to the user. This PR is the **seam**, not a wire.

## Wiring example

\`\`\`python
from similarity import find_near_duplicates

def my_llm_matcher(candidate, existing):
    # Your call to your LLM provider goes here.
    # Return [{id, similarity, reason}, ...] for matches the deterministic
    # check missed. The result is merged into the proposal annotations.
    ...

matches = find_near_duplicates(
    candidate_text=text,
    candidate_id=\"C99\",
    candidate_session=\"...\",
    existing_entries=entries,
    extra_matcher=my_llm_matcher,    # opt-in, costs tokens
)
\`\`\`

## Tests

6 new unit tests in \`test_similarity.py\`:

- \`extra_matcher\` called when deterministic finds nothing
- \`extra_matcher\` **skipped** when deterministic already matched (cost-discipline contract)
- Errors caught, no crash, stderr surfacing
- \`self_id\` from extras filtered out
- Malformed return values (\`None\`, missing \`id\`) filtered
- Returning \`None\` treated as empty list

## Documentation

\`harness/README.md\` gets a new subsection \"Opt-in semantic similarity (LLM / embedding seam)\" with the wiring pattern, code example, and notes on cost-discipline + defensive behavior.

## Verification

- [x] 221 unit tests pass (was 215, +6)
- [x] 16/16 fixtures pass, \`false_promotion_rate=0%\`
- [x] 8/8 rule contracts hold
- [x] 8/8 evidence bundles valid (schema + traceability)
- [x] No new runtime dependencies
- [x] No default-on LLM calls (the *\"0 tokens by default\"* promise is preserved)

## Out of scope

- Anthropic / OpenAI SDK adapters — separate PRs, each with its own provider-specific concerns
- Default-on LLM matching — would break the conservative-by-default contract
- Embedding cache / persistence — premature without an actual provider in place

🤖 Generated with [Claude Code](https://claude.com/claude-code)